### PR TITLE
refactor: type generation

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -33,5 +33,6 @@ jobs:
 
       - name: Lint Prettier
         run: npm run lint:prettier
-        env:
-          CI: true
+
+      - name: Validate schemas
+        run: npm run validate:schemas

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,10 +8,11 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Program",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
       "args": ["${workspaceFolder}/src/index.ts"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "generate:schemas",
       "env": {
         "NODE_ENV": "development",
         "TS_NODE_SKIP_IGNORE": "true"
@@ -21,10 +22,11 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Program - memory-db",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
       "args": ["${workspaceFolder}/src/index.ts", "--compile-schemas"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "generate:schemas",
       "env": {
         "STACKS_SIDECAR_DB": "memory",
         "NODE_ENV": "development",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "generate:schemas",
+      "type": "npm",
+      "script": "generate:schemas",
+      "presentation": {
+        "reveal": "silent"
+      }
+    }
+  ]
+}

--- a/docs/api/transaction/get-transactions.schema.json
+++ b/docs/api/transaction/get-transactions.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "GET request that returns transactions",
   "type": "object",
-  "additionalProperties": false,
   "required": ["results"],
   "properties": {
     "results": {

--- a/docs/entities/transactions/abstract-transaction.schema.json
+++ b/docs/entities/transactions/abstract-transaction.schema.json
@@ -26,8 +26,7 @@
       "type": "integer"
     },
     "tx_status": {
-      "type": "string",
-      "enum": ["success", "pending", "failed"]
+      "$ref": "./transaction-status.schema.json"
     },
     "fee_rate": {
       "type": "string",

--- a/docs/entities/transactions/abstract-tx-event.schema.json
+++ b/docs/entities/transactions/abstract-tx-event.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "description": "Abstract transaction event. Only present in `smart_contract` and `contract_call` tx types.",
-  "additionalProperties": false,
   "required": ["events"],
   "properties": {
     "events": {

--- a/docs/entities/transactions/transaction-0-token-transfer.schema.json
+++ b/docs/entities/transactions/transaction-0-token-transfer.schema.json
@@ -13,7 +13,6 @@
     {
       "type": "object",
       "required": ["tx_type", "token_transfer"],
-      "additionalProperties": false,
       "properties": {
         "tx_type": {
           "type": "string",

--- a/docs/entities/transactions/transaction-1-smart-contract.schema.json
+++ b/docs/entities/transactions/transaction-1-smart-contract.schema.json
@@ -12,7 +12,6 @@
     },
     {
       "type": "object",
-      "additionalProperties": false,
       "required": ["tx_type", "smart_contract"],
       "properties": {
         "tx_type": {

--- a/docs/entities/transactions/transaction-2-contract-call.schema.json
+++ b/docs/entities/transactions/transaction-2-contract-call.schema.json
@@ -12,7 +12,6 @@
     },
     {
       "type": "object",
-      "additionalProperties": false,
       "required": ["tx_type", "contract_call"],
       "properties": {
         "tx_type": {

--- a/docs/entities/transactions/transaction-3-poison-microblock.schema.json
+++ b/docs/entities/transactions/transaction-3-poison-microblock.schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "title": "PoisonMicroblockTransaction",
   "description": "Describes representation of a Type 3 Stacks 2.0 transaction: Poison Microblock",
-  "additionalProperties": false,
   "allOf": [
     {
       "$ref": "./abstract-transaction.schema.json"

--- a/docs/entities/transactions/transaction-4-coinbase.schema.json
+++ b/docs/entities/transactions/transaction-4-coinbase.schema.json
@@ -17,6 +17,7 @@
         },
         "coinbase_payload": {
           "type": "object",
+          "additionalProperties": false,
           "required": ["data"],
           "properties": {
             "data": {

--- a/docs/entities/transactions/transaction-status.schema.json
+++ b/docs/entities/transactions/transaction-status.schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "All states a transaction can have",
+  "type": "string",
+  "enum": ["success", "pending", "failed"]
+}

--- a/docs/entities/transactions/transaction.schema.json
+++ b/docs/entities/transactions/transaction.schema.json
@@ -3,27 +3,21 @@
   "type": "object",
   "title": "Transaction",
   "description": "Describes all transaction types on Stacks 2.0 blockchain",
-  "additionalProperties": false,
   "oneOf": [
     {
-      "$ref": "./transaction-0-token-transfer.schema.json",
-      "title": "TxType0"
+      "$ref": "./transaction-0-token-transfer.schema.json"
     },
     {
-      "$ref": "./transaction-1-smart-contract.schema.json",
-      "title": "TxType1"
+      "$ref": "./transaction-1-smart-contract.schema.json"
     },
     {
-      "$ref": "./transaction-2-contract-call.schema.json",
-      "title": "TxType2"
+      "$ref": "./transaction-2-contract-call.schema.json"
     },
     {
-      "$ref": "./transaction-3-poison-microblock.schema.json",
-      "title": "TxType3"
+      "$ref": "./transaction-3-poison-microblock.schema.json"
     },
     {
-      "$ref": "./transaction-4-coinbase.schema.json",
-      "title": "TxType4"
+      "$ref": "./transaction-4-coinbase.schema.json"
     }
   ]
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13,9 +13,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './api/transaction/get-transactions.schema.json'
+                $ref: ./api/transaction/get-transactions.schema.json
               example:
-                $ref: './api/transaction/get-transactions.example.json'
+                $ref: ./api/transaction/get-transactions.example.json
   /transactions/{tx_id}:
     parameters:
       - name: tx_id

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,12 +1,10 @@
 {
   "name": "@blockstack/stacks-blockchain-sidecar-types",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "access": "public",
   "description": "TypeScript descriptions of Stacks 2.0 sidecar API entities",
   "main": "index.ts",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "scripts": {},
   "author": "@blockstack",
   "license": "ISC",
   "files": [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,5 +31,5 @@ function clean() {
 }
 
 exports.default = parallel(flattenSchemas, copyFiles);
-
+exports.flattenSchemas = flattenSchemas;
 exports.deployDocs = series(deployToGithubPages, clean);

--- a/package-lock.json
+++ b/package-lock.json
@@ -874,6 +874,15 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/ajv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ajv/-/ajv-1.0.0.tgz",
+      "integrity": "sha1-T7JEB0Ly9sMOf7B5e4OfxvaWaCo=",
+      "dev": true,
+      "requires": {
+        "ajv": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -1010,15 +1019,6 @@
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
-      }
-    },
-    "@types/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/glob": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,17 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
+      "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ono": "^7.1.0",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1"
+      }
+    },
     "@awaitjs/express": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@awaitjs/express/-/express-0.5.1.tgz",
@@ -739,6 +750,12 @@
         "chalk": "^3.0.0"
       }
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.1.tgz",
+      "integrity": "sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A==",
+      "dev": true
+    },
     "@microsoft/tsdoc": {
       "version": "0.12.18",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.18.tgz",
@@ -995,6 +1012,15 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -1052,6 +1078,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
+    },
+    "@types/json-schema-merge-allof": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
+      "integrity": "sha512-v6iCEk4Sxy1twlCTtrRxMqSHX0vuLJ7Ql4hiIUZRMOswxtlUeybIfYaZIj7pX747RBczG2YtBm4Fn6sqKzeY2Q==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "*"
+      }
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -3513,6 +3548,29 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "compute-gcd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
+      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
+      "dev": true,
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
+      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
+      "dev": true,
+      "requires": {
+        "compute-gcd": "^1.2.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
       }
     },
     "concat-map": {
@@ -8834,6 +8892,26 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
+    },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
+      "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
+      "dev": true,
+      "requires": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
     },
     "json-schema-ref-parser": {
       "version": "6.1.0",
@@ -14516,6 +14594,43 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
+      "dev": true
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
+      "dev": true
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "dev": true,
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "dev": true,
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
+      "dev": true
     },
     "validator": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:openapi": "lint-openapi ./docs/openapi.yaml",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx -f codeframe --fix",
     "migrate": "ts-node node_modules/.bin/node-pg-migrate -j ts",
-    "generate:types": "gulp --silent && ts-node ./scripts/generate-types.ts",
+    "generate:types": "ts-node ./scripts/generate-types.ts",
     "generate:docs": "redoc-cli bundle --output .tmp/index.html docs/openapi.yaml",
     "validate:schemas": "gulp --silent && ./scripts/validate-schemas.ts",
     "deploy:docs": "npm run generate:types && npm run generate:docs && gulp deployDocs"
@@ -52,6 +52,7 @@
     "typescript": "^3.8.3"
   },
   "devDependencies": {
+    "@apidevtools/json-schema-ref-parser": "^8.0.0",
     "@blockstack/eslint-config": "^1.0.3",
     "@blockstack/prettier-config": "0.0.6",
     "@types/bluebird": "^3.5.30",
@@ -61,6 +62,8 @@
     "@types/express": "^4.17.3",
     "@types/glob": "^7.1.1",
     "@types/jest": "^25.1.4",
+    "@types/json-schema": "^7.0.4",
+    "@types/json-schema-merge-allof": "^0.6.0",
     "@types/node": "^13.7.4",
     "@types/pg": "^7.14.3",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
@@ -77,6 +80,7 @@
     "gulp-prettier": "^3.0.0",
     "ibm-openapi-validator": "^0.26.0",
     "jest": "^25.2.1",
+    "json-schema-merge-allof": "^0.7.0",
     "json-schema-to-typescript": "^8.2.0",
     "jsonlint-cli": "^1.0.1",
     "node-watch": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx -f codeframe --fix",
     "migrate": "ts-node node_modules/.bin/node-pg-migrate -j ts",
     "generate:types": "ts-node ./scripts/generate-types.ts",
+    "generate:schemas": "gulp --silent && npm run generate:types",
     "generate:docs": "redoc-cli bundle --output .tmp/index.html docs/openapi.yaml",
-    "validate:schemas": "gulp --silent && ./scripts/validate-schemas.ts",
+    "validate:schemas": "gulp flattenSchemas --silent && ./scripts/validate-schemas.ts",
     "deploy:docs": "npm run generate:types && npm run generate:docs && gulp deployDocs"
   },
   "repository": {
@@ -55,6 +56,7 @@
     "@apidevtools/json-schema-ref-parser": "^8.0.0",
     "@blockstack/eslint-config": "^1.0.3",
     "@blockstack/prettier-config": "0.0.6",
+    "@types/ajv": "^1.0.0",
     "@types/bluebird": "^3.5.30",
     "@types/bn.js": "^4.11.6",
     "@types/compression": "^1.7.0",
@@ -88,6 +90,7 @@
     "redoc-cli": "^0.9.7",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.8.1",
+    "tsconfig-paths": "^3.9.0",
     "yaml-lint": "^1.2.4"
   }
 }

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -1,35 +1,47 @@
-#!/usr/bin/env ts-node
-'use strict';
-
 import { promises as fs } from 'fs';
+import * as path from 'path';
+
 import * as glob from 'glob';
+import { JSONSchema4 } from 'json-schema';
+import * as mergeSchemas from 'json-schema-merge-allof';
+import * as deref from '@apidevtools/json-schema-ref-parser';
 import { compile } from 'json-schema-to-typescript';
 
-const dataEncoding = 'utf8';
-const shouldGenerateTypeFor = (schema: { title?: string }) => !!schema.title;
-const typeFileName = '.tmp/index.ts';
+const root = path.join(__dirname, '..');
+const docsPath = path.join(root, 'docs');
+const tmpPath = path.join(root, '.tmp');
+const typeFilePath = path.join(tmpPath, 'index.d.ts');
 
-const clearFile = async () => await fs.writeFile(typeFileName, '');
+const clearFile = async () => {
+  try {
+    await fs.access(tmpPath);
+  } catch (e) {
+    await fs.mkdir(tmpPath);
+  }
+  await fs.writeFile(typeFilePath, '', 'utf8');
+};
 
-glob('.tmp/**/*.schema.json', (_err, files) => {
-  if (files.length === 0) {
-    console.log('No schemas. Have you ran `yarn deref-schemas`?');
+glob(path.join(docsPath, '**/*.schema.json'), async (err, files) => {
+  if (err) throw err;
+
+  await clearFile();
+
+  for await (const file of files) {
+    const derefedSchema = await deref.dereference(file);
+    const schema = mergeSchemas(derefedSchema, {
+      ignoreAdditionalProperties: true,
+    });
+    if (!schema.title) continue;
+    if (schema.type === 'object') {
+      schema.additionalProperties = false;
+    }
+    const outputType = await compile(schema as JSONSchema4, schema.title, {
+      bannerComment: '',
+      strictIndexSignatures: true,
+      declareExternallyReferenced: false,
+    });
+    await fs.appendFile(typeFilePath, outputType);
   }
 
-  (async function () {
-    await clearFile();
-
-    for await (const file of files) {
-      const schema = JSON.parse(await fs.readFile(file, dataEncoding));
-
-      if (!shouldGenerateTypeFor(schema)) continue;
-
-      const result = await compile(schema, schema.title, {
-        bannerComment: '',
-      });
-
-      await fs.appendFile(typeFileName, result);
-    }
-    process.exit(0);
-  })();
+  process.exit(0);
 });

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env ts-node
-'use strict';
 
 import * as fs from 'fs';
 

--- a/src/api/validate.ts
+++ b/src/api/validate.ts
@@ -1,0 +1,8 @@
+import * as Ajv from 'ajv';
+
+export async function validate(schema: any, data: any) {
+  if (process.env.NODE_ENV !== 'development') return;
+  const ajv = new Ajv({ schemaId: 'auto' });
+  const valid = await ajv.validate(schema, data);
+  if (!valid) throw new Error(`Schema validation:\n\n ${JSON.stringify(ajv.errors, null, 2)}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,9 @@ import { TransactionPayloadTypeID } from './p2p/tx';
 loadDotEnv();
 
 const compileSchemas = process.argv.includes('--compile-schemas');
-const generateSchemas = () => exec('npm run generate:types');
+const generateSchemas = () => exec('npm run generate:schemas');
 
 if (compileSchemas) {
-  generateSchemas();
   watch('./docs', { recursive: true, filter: /\.schema\.json$/ }, () => generateSchemas());
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,10 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
-      "@entities": [".tmp/index.ts"]
+      "@entities": [".tmp/index.ts"],
+      "@schemas/*": [".tmp/*"]
     }
   },
-  "include": ["src/**/*", "migrations/**/*", "tests/**/*"],
-  "exclude": ["lib", ".tmp/**/*"]
+  "include": ["src/**/*", "migrations/**/*", "tests/**/*", ".tmp/**/*.schema.json"],
+  "exclude": ["lib", ".tmp"]
 }


### PR DESCRIPTION
- Improves generation of types, less redundancy in output file.
- Adds CI job to validate examples
- Uses a load of npm packages, but flow actually works pretty nice (previously derefing was done with gulp task before):
  1. Parse and de-`$ref` the schema files with [`@apidevtools/json-schema-ref-parser`](https://github.com/APIDevTools/json-schema-ref-parser)
  2. Use [`json-schema-merge-allof`](https://github.com/mokkabonna/json-schema-merge-allof) to merge `allOf` with some sensible logic that ignores `additionalProperties: false`
  3. Compile them to TypeScript types with [`json-schema-to-typescript`](https://github.com/bcherny/json-schema-to-typescript)
- Manually publishing types package for now
- Adds schema validation to `/tx` and `/tx/:tx_id` routes in dev mode

[See new output types here](https://gist.github.com/kyranjamie/11a6acaed43c0e9c3334bf2c002ebb96)