### PR TITLE
feat: add GET contract API endpoint

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -1,11 +1,11 @@
+import { Server } from 'http';
 import * as express from 'express';
 import * as compression from 'compression';
 import { addAsync, ExpressWithAsync } from '@awaitjs/express';
 import { DataStore } from '../datastore/common';
-
 import { createTxRouter } from './routes/tx';
-import { Server } from 'http';
 import { createDebugRouter } from './routes/debug';
+import { createContractRouter } from './routes/contract';
 
 export function startApiServer(
   datastore: DataStore
@@ -30,6 +30,7 @@ export function startApiServer(
     app.disable('x-powered-by');
 
     app.use('/tx', createTxRouter(datastore));
+    app.use('/contract', createContractRouter(datastore));
     app.use('/debug', createDebugRouter(datastore));
     app.use('/status', (req, res) => {
       res.status(200).json({ status: 'ready' });

--- a/src/api/routes/contract.ts
+++ b/src/api/routes/contract.ts
@@ -1,0 +1,17 @@
+import * as express from 'express';
+import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import * as cors from 'cors';
+import { DataStore } from '../../datastore/common';
+
+export function createContractRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+  router.use(cors());
+
+  router.getAsync('/:contract_id', async (req, res) => {
+    const { contract_id } = req.params;
+    const contract = await db.getSmartContract(contract_id);
+    res.json(contract);
+  });
+
+  return router;
+}


### PR DESCRIPTION
Minor sidecar API feature to include a GET `/contract/:contract-id` endpoint