### PR TITLE
increase core-node RPC proxy timeout

### DIFF
--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -17,6 +17,7 @@ export function createCoreNodeRpcProxyRouter(): express.Router {
   const stacksNodeRpcProxy = expressProxy(stacksNodeRpcEndpoint, {
     https: false,
     proxyReqPathResolver: proxyPathResolver,
+    timeout: 30000, // 30 seconds
   });
 
   router.use(stacksNodeRpcProxy);


### PR DESCRIPTION
Fix the 504 errors when the core-node RPC server takes several seconds to respond