### PR TITLE
feat: broadcast from faucet

### DIFF
--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -397,9 +397,12 @@ export function createDebugRouter(db: DataStore): RouterWithAsync {
 
       const hex = tx.serialize().toString('hex');
 
+      const { txId } = await sendCoreTx(tx.serialize());
+
       res.json({
         success: true,
-        tx: hex,
+        txId,
+        txRaw: hex,
       });
     } catch (error) {
       console.log(error);

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -377,19 +377,12 @@ export function createDebugRouter(db: DataStore): RouterWithAsync {
   router.postAsync('/faucet', async (req, res) => {
     try {
       const { address } = req.query;
-      const { FAUCET_PRIVATE_KEY } = process.env;
-      if (!FAUCET_PRIVATE_KEY) {
-        res.json({
-          success: false,
-          error: 'Faucet not setup',
-        });
-        return;
-      }
+      const privateKey = process.env.FAUCET_PRIVATE_KEY || testnetKeys[0].secretKey;
 
-      const senderAddress = getAddressFromPrivateKey(FAUCET_PRIVATE_KEY);
+      const senderAddress = getAddressFromPrivateKey(privateKey);
       const nonce = await new StacksCoreRpcClient().getAccountNonce(senderAddress);
 
-      const tx = makeSTXTokenTransfer(address, new BN(10e3), new BN(10), FAUCET_PRIVATE_KEY, {
+      const tx = makeSTXTokenTransfer(address, new BN(10e3), new BN(10), privateKey, {
         nonce: new BN(nonce),
         version: TransactionVersion.Testnet,
         memo: 'Faucet',


### PR DESCRIPTION
Forgot to include this functionality.

Also, can we setup the ENV variable with a private key for a genesis block address? So we can fully wire this up?