### PR TITLE
Fix: sender address in contract name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ lib
 stacks-blockchain/dist-tool/.*
 stacks-blockchain/.chaindata
 src/schemas
+
+# Webstorm editor files
+.idea

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -6,7 +6,7 @@ import { CoreNodeParsedTxMessage } from '../event-stream/core-node-message';
 import { TransactionAuthTypeID, TransactionPayloadTypeID } from '../p2p/tx';
 import { c32address } from 'c32check';
 import { NotImplementedError } from '../errors';
-import { Address, serializeCV, addressFromHashMode } from '@blockstack/stacks-transactions';
+import { addressFromHashMode, addressToString } from '@blockstack/stacks-transactions';
 
 export interface DbBlock {
   block_hash: string;
@@ -207,11 +207,13 @@ export function createDbTxFromCoreMsg(msg: CoreNodeParsedTxMessage): DbTx {
       break;
     }
     case TransactionPayloadTypeID.SmartContract: {
-      const sender_address = addressFromHashMode(
-        rawTx.auth.originCondition.hashMode as number,
-        rawTx.version as number,
-        rawTx.auth.originCondition.signer.toString('hex')
-      ).toString();
+      const sender_address = addressToString(
+        addressFromHashMode(
+          rawTx.auth.originCondition.hashMode as number,
+          rawTx.version as number,
+          rawTx.auth.originCondition.signer.toString('hex')
+        )
+      );
       dbTx.smart_contract_contract_id = sender_address + '.' + rawTx.payload.name;
       dbTx.smart_contract_source_code = rawTx.payload.codeBody;
       break;


### PR DESCRIPTION
### What this does

`addressFromHashMode` needs to be wrapped in `addressToString`. Currently it returns `[object Object]`