### PR TITLE
feat: add string literal type for tx_type

### DIFF
--- a/docs/entities/transactions/transaction-type.schema.json
+++ b/docs/entities/transactions/transaction-type.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TransactionType",
+  "description": "String literal of all Stacks 2.0 transaction types",
+  "type": "string",
+  "enum": ["token_transfer", "smart_contract", "contract_call", "poison_microblock", "coinbase"]
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-blockchain-sidecar-types",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "access": "public",
   "description": "TypeScript descriptions of Stacks 2.0 sidecar API entities",
   "main": "index.d.ts",


### PR DESCRIPTION
This PR creates a string literal for tx types, available in `@blockstack/stacks-blockchain-sidecar-types` package
