### PR TITLE
feat: conform to schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -945,12 +945,6 @@
         "ajv": "*"
       }
     },
-    "@types/assert": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.4.6.tgz",
-      "integrity": "sha512-r/N9gGdYr2MfZSbdi6w6VH3+qS1KboBqZ0bkDiTD2RdAls3smYDK/jy8jhGyGTZglFgLTCknH1MBJG8M4sd+6A==",
-      "dev": true
-    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -14,14 +14,13 @@ import {
   bufferToHexPrefixString,
   ElementType,
 } from '../../helpers';
-import { NotImplementedError } from '../../errors';
 import { readClarityValueArray, readTransactionPostConditions } from '../../p2p/tx';
 import { serializeCV } from '@blockstack/stacks-transactions';
 import { BufferReader } from '../../binary-reader';
 
 import { serializePostCondition, serializePostConditionMode } from '../serializers/post-conditions';
 import { TransactionEvent } from '../../../.tmp/index';
-import { DbEvent, DbSmartContractEvent, DbFtEvent, DbNftEvent } from '../../datastore/common';
+import { DbSmartContractEvent, DbFtEvent, DbNftEvent } from '../../datastore/common';
 
 function getTypeString(typeId: DbTxTypeId): Transaction['tx_type'] {
   switch (typeId) {
@@ -108,7 +107,7 @@ export async function getTxFromDataStore(
   if (!txQuery.found) {
     return { found: false };
   }
-  const { result: dbTxEvents } = await db.getTxEvents(txId);
+  const { results: dbTxEvents } = await db.getTxEvents(txId);
   const dbTx = txQuery.result;
   const apiTx: Partial<Transaction> = {
     block_hash: dbTx.block_hash,

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -16,15 +16,15 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
   router.getAsync('/', async (req, res) => {
     const txs = await db.getTxList();
     // TODO: fix these duplicate db queries
-    const result = await Bluebird.mapSeries(txs.result, async tx => {
+    const results = await Bluebird.mapSeries(txs.results, async tx => {
       const txQuery = await getTxFromDataStore(tx.tx_id, db);
       if (!txQuery.found) {
         throw new Error('unexpected tx not found -- fix tx enumeration query');
       }
       return txQuery.result;
     });
-    await validate(txResultsSchema, result);
-    res.json(result);
+    await validate(txResultsSchema, { results });
+    res.json({ results });
   });
 
   router.getAsync('/stream', async (req, res) => {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -167,12 +167,12 @@ export interface DataStoreUpdateData {
 
 export interface DataStore extends DataStoreEventEmitter {
   getBlock(blockHash: string): Promise<{ found: true; result: DbBlock } | { found: false }>;
-  getBlocks(count?: number): Promise<{ result: DbBlock[] }>;
+  getBlocks(count?: number): Promise<{ results: DbBlock[] }>;
 
   getTx(txId: string): Promise<{ found: true; result: DbTx } | { found: false }>;
-  getTxList(count?: number): Promise<{ result: DbTx[] }>;
+  getTxList(count?: number): Promise<{ results: DbTx[] }>;
 
-  getTxEvents(txId: string): Promise<{ result: DbEvent[] }>;
+  getTxEvents(txId: string): Promise<{ results: DbEvent[] }>;
 
   getSmartContract(
     contractId: string

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -8,7 +8,6 @@ import {
   DbNftEvent,
   DbSmartContractEvent,
   DbSmartContract,
-  DbEvent,
   DataStoreEventEmitter,
   DataStoreUpdateData,
 } from './common';
@@ -23,7 +22,7 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   readonly smartContractEvents: Map<string, DbSmartContractEvent> = new Map();
   readonly smartContracts: Map<string, DbSmartContract> = new Map();
 
-  async update(data: DataStoreUpdateData): Promise<void> {
+  async update(data: DataStoreUpdateData) {
     await this.updateBlock(data.block);
     for (const tx of data.txs) {
       await this.updateTx(tx);
@@ -49,7 +48,7 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     });
   }
 
-  updateBlock(block: DbBlock): Promise<void> {
+  updateBlock(block: DbBlock) {
     const blockStored = { ...block };
 
     // Detect reorg event by checking for existing block with same height.
@@ -89,39 +88,37 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     });
   }
 
-  getBlock(blockHash: string): Promise<{ found: true; result: DbBlock } | { found: false }> {
+  getBlock(blockHash: string) {
     const block = this.blocks.get(blockHash);
     if (block === undefined) {
-      return Promise.resolve({ found: false });
+      return Promise.resolve({ found: false } as const);
     }
     return Promise.resolve({ found: true, result: block });
   }
 
-  getBlocks(count = 50): Promise<{ result: DbBlock[] }> {
+  getBlocks(count = 50) {
     const results = [...this.blocks.values()]
       .filter(b => b.canonical)
       .sort((a, b) => b.block_height - a.block_height)
       .slice(0, count);
-    return Promise.resolve({
-      result: results,
-    });
+    return Promise.resolve({ results });
   }
 
-  updateTx(tx: DbTx): Promise<void> {
+  updateTx(tx: DbTx) {
     const txStored = { ...tx };
     this.txs.set(tx.tx_id, txStored);
     return Promise.resolve();
   }
 
-  getTx(txId: string): Promise<{ found: true; result: DbTx } | { found: false }> {
+  getTx(txId: string) {
     const tx = this.txs.get(txId);
     if (tx === undefined) {
-      return Promise.resolve({ found: false });
+      return Promise.resolve({ found: false } as const);
     }
     return Promise.resolve({ found: true, result: tx });
   }
 
-  getTxList(count = 50): Promise<{ result: DbTx[] }> {
+  getTxList(count = 50) {
     const results = [...this.txs.values()]
       .filter(tx => tx.canonical)
       .sort((a, b) => {
@@ -131,12 +128,10 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
         return b.block_height - a.block_height;
       })
       .slice(0, count);
-    return Promise.resolve({
-      result: results,
-    });
+    return Promise.resolve({ results });
   }
 
-  getTxEvents(txId: string): Promise<{ result: DbEvent[] }> {
+  getTxEvents(txId: string) {
     const stxEvents = [...this.stxTokenEvents.values()].filter(e => e.tx_id === txId);
     const ftEvents = [...this.fungibleTokenEvents.values()].filter(e => e.tx_id === txId);
     const nftEvents = [...this.nonFungibleTokenEvents.values()].filter(e => e.tx_id === txId);
@@ -146,40 +141,38 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     const allEvents = [...stxEvents, ...ftEvents, ...nftEvents, ...smartContractEvents].sort(
       e => e.event_index
     );
-    return Promise.resolve({ result: allEvents });
+    return Promise.resolve({ results: allEvents });
   }
 
-  updateStxEvent(event: DbStxEvent): Promise<void> {
+  updateStxEvent(event: DbStxEvent) {
     this.stxTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 
-  updateFtEvent(event: DbFtEvent): Promise<void> {
+  updateFtEvent(event: DbFtEvent) {
     this.fungibleTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 
-  updateNftEvent(event: DbNftEvent): Promise<void> {
+  updateNftEvent(event: DbNftEvent) {
     this.nonFungibleTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 
-  updateSmartContractEvent(event: DbSmartContractEvent): Promise<void> {
+  updateSmartContractEvent(event: DbSmartContractEvent) {
     this.smartContractEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 
-  updateSmartContract(smartContract: DbSmartContract): Promise<void> {
+  updateSmartContract(smartContract: DbSmartContract) {
     this.smartContracts.set(smartContract.contract_id, { ...smartContract });
     return Promise.resolve();
   }
 
-  getSmartContract(
-    contractId: string
-  ): Promise<{ found: true; result: DbSmartContract } | { found: false }> {
+  getSmartContract(contractId: string) {
     const smartContract = this.smartContracts.get(contractId);
     if (smartContract === undefined) {
-      return Promise.resolve({ found: false });
+      return Promise.resolve({ found: false } as const);
     }
     return Promise.resolve({ found: true, result: smartContract });
   }


### PR DESCRIPTION
A few changes that I hope you're onboard with @zone117x 

- Omit type repetition: imo less error-prone and easier to read relying on the implemented types in `./common.ts`, than retyping. See use of `as const` where necessary. This is equally as type strong.
- Alternate between result and results. Don't think consistency is necessary here, favouring readability, but if you disagree, maybe we can choose another name altogether?
- Schema validation works now 👍 