### PR TITLE
feat: add hex prefix if not given, dev-friendly

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  range: 30..70 # coverage lower than 30 is red, higher than 70 green, between color code
+
+  status:
+    project: # settings affecting project coverage
+      default:
+        target: auto # auto % coverage target
+        threshold: 2%  # allow for 2% reduction of coverage without failing
+
+    # do not run coverage on patch nor changes
+    patch: false

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -3,7 +3,7 @@ import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import * as Bluebird from 'bluebird';
 import { DataStore, DbTx } from '../../datastore/common';
 import { getTxFromDataStore } from '../controllers/db-controller';
-import { timeout, waiter } from '../../helpers';
+import { timeout, waiter, has0xPrefix } from '../../helpers';
 import { validate } from '../validate';
 import * as txSchema from '../../../.tmp/entities/transactions/transaction.schema.json';
 // import * as txSchema from '../entities/transactions/transaction.schema.json';
@@ -78,6 +78,11 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
 
   router.getAsync('/:tx_id', async (req, res) => {
     const { tx_id } = req.params;
+
+    if (!has0xPrefix(tx_id)) {
+      return res.redirect('/sidecar/v1/tx/0x' + tx_id);
+    }
+
     const txQuery = await getTxFromDataStore(tx_id, db);
     if (!txQuery.found) {
       res.status(404).json({ error: `could not find transaction by ID ${tx_id}` });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -294,3 +294,5 @@ export function cssEscape(value: string): string {
   }
   return result;
 }
+
+export const has0xPrefix = (id: string) => id.substr(0, 2) === '0x';

--- a/src/tests/helpers-tests.ts
+++ b/src/tests/helpers-tests.ts
@@ -1,6 +1,16 @@
-import { getCurrentGitTag } from '../helpers';
+import { getCurrentGitTag, has0xPrefix } from '../helpers';
 
 test('get git tag', () => {
   const tag = getCurrentGitTag();
   expect(tag).toBeTruthy();
+});
+
+describe('has0xPrefix()', () => {
+  test('falsy case, where there be no 0x', () => {
+    expect(has0xPrefix('la-la, no prefixie here')).toEqual(false);
+  });
+
+  test('it returns true when there is, infact, a 0x prefix', () => {
+    expect(has0xPrefix('0xlkjsdkljskljdkjlsdfkljs')).toEqual(true);
+  });
 });


### PR DESCRIPTION
Minor update but hopefully a helpful one. Added this as noticed that `broadcastTransaction` from stacks-transaction returns non-prefixed txid.