### PR TITLE
Feat/pg retain orphaned events

### DIFF
--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -107,7 +107,7 @@ export async function getTxFromDataStore(
   if (!txQuery.found) {
     return { found: false };
   }
-  const { results: dbTxEvents } = await db.getTxEvents(txId);
+  const { results: dbTxEvents } = await db.getTxEvents(txId, txQuery.result.block_hash);
   const dbTx = txQuery.result;
   const apiTx: Partial<Transaction> = {
     block_hash: dbTx.block_hash,

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -157,12 +157,14 @@ export type DataStoreEventEmitter = StrictEventEmitter<
 
 export interface DataStoreUpdateData {
   block: DbBlock;
-  txs: DbTx[];
-  stxEvents: DbStxEvent[];
-  ftEvents: DbFtEvent[];
-  nftEvents: DbNftEvent[];
-  contractLogEvents: DbSmartContractEvent[];
-  smartContracts: DbSmartContract[];
+  txs: {
+    tx: DbTx;
+    stxEvents: DbStxEvent[];
+    ftEvents: DbFtEvent[];
+    nftEvents: DbNftEvent[];
+    contractLogEvents: DbSmartContractEvent[];
+    smartContracts: DbSmartContract[];
+  }[];
 }
 
 export interface DataStore extends DataStoreEventEmitter {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -174,7 +174,7 @@ export interface DataStore extends DataStoreEventEmitter {
   getTx(txId: string): Promise<{ found: true; result: DbTx } | { found: false }>;
   getTxList(count?: number): Promise<{ results: DbTx[] }>;
 
-  getTxEvents(txId: string): Promise<{ results: DbEvent[] }>;
+  getTxEvents(txId: string, blockHash: string): Promise<{ results: DbEvent[] }>;
 
   getSmartContract(
     contractId: string

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -24,27 +24,27 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
 
   async update(data: DataStoreUpdateData) {
     await this.updateBlock(data.block);
-    for (const tx of data.txs) {
-      await this.updateTx(tx);
-    }
-    for (const stxEvent of data.stxEvents) {
-      await this.updateStxEvent(stxEvent);
-    }
-    for (const ftEvent of data.ftEvents) {
-      await this.updateFtEvent(ftEvent);
-    }
-    for (const nftEvent of data.nftEvents) {
-      await this.updateNftEvent(nftEvent);
-    }
-    for (const contractLog of data.contractLogEvents) {
-      await this.updateSmartContractEvent(contractLog);
-    }
-    for (const smartContract of data.smartContracts) {
-      await this.updateSmartContract(smartContract);
+    for (const entry of data.txs) {
+      await this.updateTx(entry.tx);
+      for (const stxEvent of entry.stxEvents) {
+        await this.updateStxEvent(entry.tx, stxEvent);
+      }
+      for (const ftEvent of entry.ftEvents) {
+        await this.updateFtEvent(entry.tx, ftEvent);
+      }
+      for (const nftEvent of entry.nftEvents) {
+        await this.updateNftEvent(entry.tx, nftEvent);
+      }
+      for (const contractLog of entry.contractLogEvents) {
+        await this.updateSmartContractEvent(entry.tx, contractLog);
+      }
+      for (const smartContract of entry.smartContracts) {
+        await this.updateSmartContract(entry.tx, smartContract);
+      }
     }
     this.emit('blockUpdate', data.block);
-    data.txs.forEach(tx => {
-      this.emit('txUpdate', tx);
+    data.txs.forEach(entry => {
+      this.emit('txUpdate', entry.tx);
     });
   }
 
@@ -144,27 +144,33 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     return Promise.resolve({ results: allEvents });
   }
 
-  updateStxEvent(event: DbStxEvent) {
-    this.stxTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+  updateStxEvent(tx: DbTx, event: DbStxEvent) {
+    this.stxTokenEvents.set(`${event.tx_id}_${tx.block_hash}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 
-  updateFtEvent(event: DbFtEvent) {
-    this.fungibleTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+  updateFtEvent(tx: DbTx, event: DbFtEvent) {
+    this.fungibleTokenEvents.set(`${event.tx_id}_${tx.block_hash}_${event.event_index}`, {
+      ...event,
+    });
     return Promise.resolve();
   }
 
-  updateNftEvent(event: DbNftEvent) {
-    this.nonFungibleTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+  updateNftEvent(tx: DbTx, event: DbNftEvent) {
+    this.nonFungibleTokenEvents.set(`${event.tx_id}_${tx.block_hash}_${event.event_index}`, {
+      ...event,
+    });
     return Promise.resolve();
   }
 
-  updateSmartContractEvent(event: DbSmartContractEvent) {
-    this.smartContractEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+  updateSmartContractEvent(tx: DbTx, event: DbSmartContractEvent) {
+    this.smartContractEvents.set(`${event.tx_id}_${tx.block_hash}_${event.event_index}`, {
+      ...event,
+    });
     return Promise.resolve();
   }
 
-  updateSmartContract(smartContract: DbSmartContract) {
+  updateSmartContract(tx: DbTx, smartContract: DbSmartContract) {
     this.smartContracts.set(smartContract.contract_id, { ...smartContract });
     return Promise.resolve();
   }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -531,9 +531,10 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { results: parsed };
   }
 
-  async getTxEvents(txId: string) {
+  async getTxEvents(txId: string, blockHash: string) {
     const client = await this.pool.connect();
     const txIdBuffer = hexToBuffer(txId);
+    const blockHashBuffer = hexToBuffer(blockHash);
     try {
       const stxResults = await client.query<{
         event_index: number;
@@ -549,9 +550,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT 
           event_index, tx_id, block_height, canonical, asset_event_type_id, sender, recipient, amount 
         FROM stx_events 
-        WHERE tx_id = $1 AND canonical = true
+        WHERE tx_id = $1 AND block_hash = $2
         `,
-        [txIdBuffer]
+        [txIdBuffer, blockHashBuffer]
       );
       const ftResults = await client.query<{
         event_index: number;
@@ -568,9 +569,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT 
           event_index, tx_id, block_height, canonical, asset_event_type_id, sender, recipient, asset_identifier, amount 
         FROM ft_events 
-        WHERE tx_id = $1 AND canonical = true
+        WHERE tx_id = $1 AND block_hash = $2
         `,
-        [txIdBuffer]
+        [txIdBuffer, blockHashBuffer]
       );
       const nftResults = await client.query<{
         event_index: number;
@@ -587,9 +588,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT 
           event_index, tx_id, block_height, canonical, asset_event_type_id, sender, recipient, asset_identifier, value 
         FROM nft_events 
-        WHERE tx_id = $1 AND canonical = true
+        WHERE tx_id = $1 AND block_hash = $2
         `,
-        [txIdBuffer]
+        [txIdBuffer, blockHashBuffer]
       );
       const logResults = await client.query<{
         event_index: number;
@@ -604,9 +605,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT 
           event_index, tx_id, block_height, canonical, contract_identifier, topic, value 
         FROM contract_logs 
-        WHERE tx_id = $1 AND canonical = true
+        WHERE tx_id = $1 AND block_hash = $2
         `,
-        [txIdBuffer]
+        [txIdBuffer, blockHashBuffer]
       );
       const events = new Array<DbEvent>(
         nftResults.rowCount + ftResults.rowCount + logResults.rowCount

--- a/src/migrations/1584619633448_txs.ts
+++ b/src/migrations/1584619633448_txs.ts
@@ -89,6 +89,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('txs', 'canonical');
   pgm.createIndex('txs', 'sender_address');
 
+  pgm.addConstraint('txs', 'unique_tx_id_block_hash', `UNIQUE(tx_id, block_hash)`);
+
   pgm.addConstraint('txs', 'valid_token_transfer', `CHECK (type_id != 0 OR (
     NOT (token_transfer_recipient_address, token_transfer_amount, token_transfer_memo) IS NULL
   ))`);

--- a/src/migrations/1588252682585_stx_events.ts
+++ b/src/migrations/1588252682585_stx_events.ts
@@ -18,6 +18,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'integer',
       notNull: true,
     },
+    block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
     canonical: {
       type: 'boolean',
       notNull: true,
@@ -36,6 +40,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.createIndex('stx_events', 'tx_id');
   pgm.createIndex('stx_events', 'block_height');
+  pgm.createIndex('stx_events', 'block_hash');
   pgm.createIndex('stx_events', 'canonical');
   pgm.createIndex('stx_events', 'sender');
   pgm.createIndex('stx_events', 'recipient');

--- a/src/migrations/1588256295395_ft_events.ts
+++ b/src/migrations/1588256295395_ft_events.ts
@@ -18,6 +18,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'integer',
       notNull: true,
     },
+    block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
     canonical: {
       type: 'boolean',
       notNull: true,
@@ -40,6 +44,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.createIndex('ft_events', 'tx_id');
   pgm.createIndex('ft_events', 'block_height');
+  pgm.createIndex('ft_events', 'block_hash');
   pgm.createIndex('ft_events', 'canonical');
   pgm.createIndex('ft_events', 'asset_identifier');
   pgm.createIndex('ft_events', 'sender');

--- a/src/migrations/1588261750265_nft_events.ts
+++ b/src/migrations/1588261750265_nft_events.ts
@@ -18,6 +18,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'integer',
       notNull: true,
     },
+    block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
     canonical: {
       type: 'boolean',
       notNull: true,
@@ -40,6 +44,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.createIndex('nft_events', 'tx_id');
   pgm.createIndex('nft_events', 'block_height');
+  pgm.createIndex('nft_events', 'block_hash');
   pgm.createIndex('nft_events', 'canonical');
   pgm.createIndex('nft_events', 'asset_identifier');
   pgm.createIndex('nft_events', 'sender');

--- a/src/migrations/1588266401242_contract_logs.ts
+++ b/src/migrations/1588266401242_contract_logs.ts
@@ -18,6 +18,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'integer',
       notNull: true,
     },
+    block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
     canonical: {
       type: 'boolean',
       notNull: true,
@@ -38,6 +42,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.createIndex('contract_logs', 'tx_id');
   pgm.createIndex('contract_logs', 'block_height');
+  pgm.createIndex('contract_logs', 'block_hash');
   pgm.createIndex('contract_logs', 'canonical');
   pgm.createIndex('contract_logs', 'contract_identifier');
 

--- a/src/migrations/1588266891631_smart_contracts.ts
+++ b/src/migrations/1588266891631_smart_contracts.ts
@@ -22,6 +22,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'integer',
       notNull: true,
     },
+    block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
     source_code: {
       type: 'string',
       notNull: true,
@@ -34,6 +38,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.createIndex('smart_contracts', 'tx_id');
   pgm.createIndex('smart_contracts', 'block_height');
+  pgm.createIndex('smart_contracts', 'block_hash');
   pgm.createIndex('smart_contracts', 'canonical');
   pgm.createIndex('smart_contracts', 'contract_id');
 

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -318,12 +318,24 @@ describe('postgres datastore', () => {
     };
     await db.update({
       block: block1,
-      txs: [tx1, tx2],
-      stxEvents: [stxEvent1],
-      ftEvents: [ftEvent1],
-      nftEvents: [nftEvent1],
-      contractLogEvents: [contractLogEvent1],
-      smartContracts: [smartContract1],
+      txs: [
+        {
+          tx: tx1,
+          stxEvents: [stxEvent1],
+          ftEvents: [ftEvent1],
+          nftEvents: [nftEvent1],
+          contractLogEvents: [contractLogEvent1],
+          smartContracts: [smartContract1],
+        },
+        {
+          tx: tx2,
+          stxEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          smartContracts: [],
+        },
+      ],
     });
 
     const fetchTx1 = await db.getTx(tx1.tx_id);
@@ -442,21 +454,29 @@ describe('postgres datastore', () => {
     };
     await db.update({
       block: block1,
-      txs: [tx1],
-      stxEvents: [stxEvent1],
-      ftEvents: [ftEvent1],
-      nftEvents: [nftEvent1],
-      contractLogEvents: [contractLogEvent1],
-      smartContracts: [smartContract1],
+      txs: [
+        {
+          tx: tx1,
+          stxEvents: [stxEvent1],
+          ftEvents: [ftEvent1],
+          nftEvents: [nftEvent1],
+          contractLogEvents: [contractLogEvent1],
+          smartContracts: [smartContract1],
+        },
+      ],
     });
     await db.update({
       block: block2,
-      txs: [tx2],
-      stxEvents: [],
-      ftEvents: [],
-      nftEvents: [],
-      contractLogEvents: [],
-      smartContracts: [],
+      txs: [
+        {
+          tx: tx2,
+          stxEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          smartContracts: [],
+        },
+      ],
     });
 
     const fetchTx1 = await db.getTx(tx1.tx_id);


### PR DESCRIPTION
* Full tx event data is now returned for orphaned transaction queries. 
* The db schema change also allows event data to be recovered when a chain tip flips from non-canonical back to canonical status -- however, the reorg logic for this scenario is not yet implemented. 