### PR TITLE
fix: use paths to find custom types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,10 @@
     "baseUrl": ".",
     "paths": {
       "@entities": [".tmp/index.d.ts"],
-      "@schemas/*": [".tmp/*"]
+      "@schemas/*": [".tmp/*"],
+      "*": ["src/@types/*"]
     }
   },
   "include": ["src/**/*", ".tmp/**/*"],
-  "exclude": ["lib"]
+  "exclude": ["lib", "src/@types/*"]
 }


### PR DESCRIPTION
I was getting errors running the sidecar in dev mode because it could not find the types we have for `coinselect`. This fixes the dev task.