### PR TITLE
Batch bitcoin RPC requests

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -222,6 +222,18 @@ export function stopwatch(): {
   };
 }
 
+export async function time<T>(
+  fn: () => Promise<T>,
+  onFinish: (elapsedMs: number) => void
+): Promise<T> {
+  const watch = stopwatch();
+  try {
+    return await fn();
+  } finally {
+    onFinish(watch.getElapsed());
+  }
+}
+
 export type Json = string | number | boolean | null | { [property: string]: Json } | Json[];
 
 /**


### PR DESCRIPTION
Noticed that the faucet RPC requests on staging are sometimes timing out. Implementing the following to help diagnose and possibly fix the issue:
1. Increased logging around each RPC request.
2. Batching `getrawtransaction` requests.