### PR TITLE
Clarity values returned as repr strings

### DIFF
--- a/docs/entities/post-conditions/post-condition-2-non-fungible.schema.json
+++ b/docs/entities/post-conditions/post-condition-2-non-fungible.schema.json
@@ -24,7 +24,17 @@
           "type": "string"
         },
         "asset_value": {
-          "type": "string"
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["hex", "repr"],
+          "properties": {
+            "hex": {
+              "type": "string"
+            },
+            "repr": {
+              "type": "string"
+            }
+          }
         },
         "asset": {
           "type": "object",

--- a/docs/entities/transaction-events/transaction-event-non-fungible-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-non-fungible-asset.schema.json
@@ -29,7 +29,17 @@
               "type": "string"
             },
             "value": {
-              "type": "string"
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["hex", "repr"],
+              "properties": {
+                "hex": {
+                  "type": "string"
+                },
+                "repr": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/docs/entities/transaction-events/transaction-event-smart-contract-log.schema.json
+++ b/docs/entities/transaction-events/transaction-event-smart-contract-log.schema.json
@@ -27,7 +27,17 @@
               "type": "string"
             },
             "value": {
-              "type": "string"
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["hex", "repr"],
+              "properties": {
+                "hex": {
+                  "type": "string"
+                },
+                "repr": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/docs/entities/transactions/transaction-2-contract-call.schema.json
+++ b/docs/entities/transactions/transaction-2-contract-call.schema.json
@@ -36,7 +36,17 @@
             "function_args": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["hex", "repr"],
+                "properties": {
+                  "hex": {
+                    "type": "string"
+                  },
+                  "repr": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -507,8 +507,8 @@
       "dev": true
     },
     "@blockstack/stacks-transactions": {
-      "version": "github:blockstack/stacks-transactions-js#367dba9e7e57d6aec30f86240f6d2275500aff90",
-      "from": "github:blockstack/stacks-transactions-js#367dba9e7e57d6aec30f86240f6d2275500aff90",
+      "version": "github:blockstack/stacks-transactions-js#c5aee235595ca59465924c7bfaf6d3320b754f1a",
+      "from": "github:blockstack/stacks-transactions-js#feat/to-string",
       "requires": {
         "@types/bn.js": "^4.11.6",
         "@types/elliptic": "^6.4.12",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@awaitjs/express": "^0.5.1",
-    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#367dba9e7e57d6aec30f86240f6d2275500aff90",
+    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#feat/to-string",
     "big-integer": "^1.6.48",
     "bitcoinjs-lib": "^5.1.7",
     "bluebird": "^3.7.2",

--- a/src/api/serializers/post-conditions.ts
+++ b/src/api/serializers/post-conditions.ts
@@ -1,4 +1,7 @@
 import { c32address } from 'c32check';
+import { serializeCV } from '@blockstack/stacks-transactions';
+import { cvToString } from '@blockstack/stacks-transactions/lib/clarity';
+
 import {
   PostCondition,
   PostConditionFungible,
@@ -20,7 +23,6 @@ import {
   NonfungibleConditionCode,
 } from '../../p2p/tx';
 import { bufferToHexPrefixString } from '../../helpers';
-import { serializeCV } from '@blockstack/stacks-transactions';
 
 const assetPrincipalTypeMap = {
   [PostConditionPrincipalTypeID.Origin]: 'principal_origin',
@@ -102,8 +104,11 @@ export function serializePostCondition(pc: TransactionPostCondition): PostCondit
         type: assetInfoTypeMap[pc.assetInfoId],
         condition_code: serializeNonFungibleConditionCode(pc.conditionCode),
         principal: serializePostConditionPrincipal(pc.principal),
-        asset_value: bufferToHexPrefixString(serializeCV(pc.assetValue)),
         asset: serializePostConditionAsset(pc.asset),
+        asset_value: {
+          hex: bufferToHexPrefixString(serializeCV(pc.assetValue)),
+          repr: cvToString(pc.assetValue),
+        },
       };
   }
 }

--- a/src/core-rpc/client.ts
+++ b/src/core-rpc/client.ts
@@ -22,19 +22,23 @@ export interface CoreRpcInfo {
   parent_network_id: number;
 }
 
+export function getCoreNodeEndpoint(opts?: { host?: string; port?: number | string }) {
+  const host = opts?.host ?? process.env['STACKS_CORE_RPC_HOST'];
+  if (!host) {
+    throw new Error(`STACKS_CORE_RPC_HOST is not defined`);
+  }
+  const port = parsePort(opts?.port ?? process.env['STACKS_CORE_RPC_PORT']);
+  if (!port) {
+    throw new Error(`STACKS_CORE_RPC_PORT is not defined`);
+  }
+  return `${host}:${port}`;
+}
+
 export class StacksCoreRpcClient {
   readonly endpoint: string;
 
   constructor(opts?: { host?: string; port?: number | string }) {
-    const host = opts?.host ?? process.env['STACKS_CORE_RPC_HOST'];
-    if (!host) {
-      throw new Error(`STACKS_CORE_RPC_HOST is not defined`);
-    }
-    const port = parsePort(opts?.port ?? process.env['STACKS_CORE_RPC_PORT']);
-    if (!port) {
-      throw new Error(`STACKS_CORE_RPC_PORT is not defined`);
-    }
-    this.endpoint = `${host}:${port}`;
+    this.endpoint = getCoreNodeEndpoint(opts);
   }
 
   createUrl(path: string) {

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -50,17 +50,16 @@ describe('api tests', () => {
       new BN(36723458)
     );
 
-    const txBuilder = makeContractCall(
-      'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
-      'hello-world',
-      'fn-name',
-      [],
-      new BN(200),
-      'b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001',
-      {
-        postConditions: [pc1, pc2, pc3],
-      }
-    );
+    const txBuilder = await makeContractCall({
+      contractAddress: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
+      contractName: 'hello-world',
+      functionName: 'fn-name',
+      functionArgs: [],
+      fee: new BN(200),
+      senderKey: 'b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001',
+      postConditions: [pc1, pc2, pc3]
+    });
+
     const serialized = txBuilder.serialize();
     const tx = readTransaction(new BufferReader(serialized));
     const dbTx = createDbTxFromCoreMsg({

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -57,7 +57,7 @@ describe('api tests', () => {
       functionArgs: [],
       fee: new BN(200),
       senderKey: 'b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001',
-      postConditions: [pc1, pc2, pc3]
+      postConditions: [pc1, pc2, pc3],
     });
 
     const serialized = txBuilder.serialize();
@@ -85,7 +85,7 @@ describe('api tests', () => {
       throw Error('not found');
     }
     const expectedResp = JSON.parse(
-      '{"block_hash":"ff","block_height":123,"burn_block_time":345,"canonical":true,"tx_id":"bd5f225be4f1afb9a57f83cdc4c41cac761a8de0a87bc830323b049c6f3c5797","tx_index":2,"tx_status":"success","tx_type":"contract_call","fee_rate":"200","sender_address":"ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y","sponsored":false,"post_condition_mode":"deny","post_conditions":[{"type":"non_fungible","condition_code":"not_sent","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"},"asset_value":"0x020000000b61737365742d76616c7565","asset":{"contract_name":"hello","asset_name":"asset-name","contract_address":"STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"}},{"type":"fungible","condition_code":"sent_greater_than","amount":"123456","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"},"asset":{"contract_name":"hello-ft","asset_name":"asset-name-ft","contract_address":"STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"}},{"type":"stx","condition_code":"sent_less_than","amount":"36723458","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"}}],"contract_call":{"contract_id":"ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world","function_name":"fn-name"},"events":[]}'
+      '{"block_hash":"ff","block_height":123,"burn_block_time":345,"canonical":true,"tx_id":"bd5f225be4f1afb9a57f83cdc4c41cac761a8de0a87bc830323b049c6f3c5797","tx_index":2,"tx_status":"success","tx_type":"contract_call","fee_rate":"200","sender_address":"ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y","sponsored":false,"post_condition_mode":"deny","post_conditions":[{"type":"non_fungible","condition_code":"not_sent","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"},"asset_value":{"hex":"0x020000000b61737365742d76616c7565","repr":"\\"asset-value\\""},"asset":{"contract_name":"hello","asset_name":"asset-name","contract_address":"STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"}},{"type":"fungible","condition_code":"sent_greater_than","amount":"123456","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"},"asset":{"contract_name":"hello-ft","asset_name":"asset-name-ft","contract_address":"STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"}},{"type":"stx","condition_code":"sent_less_than","amount":"36723458","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"}}],"contract_call":{"contract_id":"ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world","function_name":"fn-name"},"events":[]}'
     );
     expect(txQuery.result).toEqual(expectedResp);
   });


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/99 - Clarity values should be returned as repr strings

All API responses which previously returned a hex string for Clarity values now returns an object:
```ts
{
  hex: string, // the raw value as a hex string
  repr: string // the new repr string
}
```

Updated fields:
* asset value in post conditions for non-fungible tokens
* asset value in non-fungible token transfer events
* contract log value in smart contract log events
* function arg values in contract call transactions