### PR TITLE
chore: point stx-tx lib to latest master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -507,8 +507,8 @@
       "dev": true
     },
     "@blockstack/stacks-transactions": {
-      "version": "github:blockstack/stacks-transactions-js#c5aee235595ca59465924c7bfaf6d3320b754f1a",
-      "from": "github:blockstack/stacks-transactions-js#feat/to-string",
+      "version": "github:blockstack/stacks-transactions-js#598ed1c3fe0b455bdd2b396150a7544f477218da",
+      "from": "github:blockstack/stacks-transactions-js#598ed1c3fe0b455bdd2b396150a7544f477218da",
       "requires": {
         "@types/bn.js": "^4.11.6",
         "@types/elliptic": "^6.4.12",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@awaitjs/express": "^0.5.1",
-    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#feat/to-string",
+    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#598ed1c3fe0b455bdd2b396150a7544f477218da",
     "big-integer": "^1.6.48",
     "bitcoinjs-lib": "^5.1.7",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
Ref: https://github.com/blockstack/stacks-blockchain-sidecar/issues/99
Now that https://github.com/blockstack/stacks-transactions-js/pull/83 is merged