### PR TITLE
Add function summary data to contract-call tx response

### DIFF
--- a/docs/entities/transactions/transaction-2-contract-call.schema.json
+++ b/docs/entities/transactions/transaction-2-contract-call.schema.json
@@ -24,7 +24,7 @@
         "contract_call": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["contract_id", "function_name"],
+          "required": ["contract_id", "function_name", "function_signature"],
           "properties": {
             "contract_id": {
               "type": "string"
@@ -33,17 +33,26 @@
               "type": "string",
               "description": "Name of the Clarity function to be invoked"
             },
+            "function_signature": {
+              "type": "string"
+            },
             "function_args": {
               "type": "array",
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["hex", "repr"],
+                "required": ["hex", "repr", "name", "type"],
                 "properties": {
                   "hex": {
                     "type": "string"
                   },
                   "repr": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
                     "type": "string"
                   }
                 }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -271,9 +271,12 @@ export interface ContractCallTransaction {
      * Name of the Clarity function to be invoked
      */
     function_name: string;
+    function_signature: string;
     function_args?: {
       hex: string;
       repr: string;
+      name: string;
+      type: string;
     }[];
   };
   post_conditions: PostCondition[];

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-blockchain-sidecar-types",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "access": "public",
   "description": "TypeScript descriptions of Stacks 2.0 sidecar API entities",
   "main": "index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8422,8 +8422,8 @@
       }
     },
     "@blockstack/stacks-transactions": {
-      "version": "github:blockstack/stacks-transactions-js#598ed1c3fe0b455bdd2b396150a7544f477218da",
-      "from": "github:blockstack/stacks-transactions-js#598ed1c3fe0b455bdd2b396150a7544f477218da",
+      "version": "github:blockstack/stacks-transactions-js#eee0518ee7bdb3869554433f94a14ae7f7ab8ce8",
+      "from": "github:blockstack/stacks-transactions-js#eee0518ee7bdb3869554433f94a14ae7f7ab8ce8",
       "requires": {
         "@types/bn.js": "^4.11.6",
         "@types/elliptic": "^6.4.12",
@@ -9147,9 +9147,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.150",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
-      "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w=="
+      "version": "4.14.152",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.152.tgz",
+      "integrity": "sha512-Vwf9YF2x1GE3WNeUMjT5bTHa2DqgUo87ocdgTScupY2JclZ5Nn7W2RLM/N0+oreexUk8uaVugR81NnTY/jNNXg=="
     },
     "@types/mime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.1",
     "@awaitjs/express": "^0.5.1",
-    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#598ed1c3fe0b455bdd2b396150a7544f477218da",
+    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#eee0518ee7bdb3869554433f94a14ae7f7ab8ce8",
     "big-integer": "^1.6.48",
     "bitcoinjs-lib": "^5.1.7",
     "bluebird": "^3.7.2",

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -3,6 +3,8 @@ import {
   NonFungibleConditionCode,
   FungibleConditionCode,
   bufferCVFromString,
+  ClarityAbi,
+  ClarityType,
 } from '@blockstack/stacks-transactions';
 import {
   createNonFungiblePostCondition,
@@ -54,12 +56,11 @@ describe('api tests', () => {
       contractAddress: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
       contractName: 'hello-world',
       functionName: 'fn-name',
-      functionArgs: [],
+      functionArgs: [{ type: ClarityType.Int, value: new BN(556) }],
       fee: new BN(200),
       senderKey: 'b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001',
       postConditions: [pc1, pc2, pc3],
     });
-
     const serialized = txBuilder.serialize();
     const tx = readTransaction(new BufferReader(serialized));
     const dbTx = createDbTxFromCoreMsg({
@@ -79,14 +80,96 @@ describe('api tests', () => {
       burn_block_time: 345,
     });
     await db.updateTx(dbTx);
+    const contractAbi: ClarityAbi = {
+      functions: [
+        {
+          name: 'fn-name',
+          args: [{ name: 'arg1', type: 'int128' }],
+          access: 'public',
+          outputs: { type: 'bool' },
+        },
+      ],
+      variables: [],
+      maps: [],
+      fungible_tokens: [],
+      non_fungible_tokens: [],
+    };
+    await db.updateSmartContract(dbTx, {
+      tx_id: dbTx.tx_id,
+      canonical: true,
+      contract_id: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world',
+      block_height: 123,
+      source_code: '()',
+      abi: JSON.stringify(contractAbi),
+    });
     const txQuery = await getTxFromDataStore(dbTx.tx_id, db);
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');
     }
-    const expectedResp = JSON.parse(
-      '{"block_hash":"ff","block_height":123,"burn_block_time":345,"canonical":true,"tx_id":"bd5f225be4f1afb9a57f83cdc4c41cac761a8de0a87bc830323b049c6f3c5797","tx_index":2,"tx_status":"success","tx_type":"contract_call","fee_rate":"200","sender_address":"ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y","sponsored":false,"post_condition_mode":"deny","post_conditions":[{"type":"non_fungible","condition_code":"not_sent","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"},"asset_value":{"hex":"0x020000000b61737365742d76616c7565","repr":"\\"asset-value\\""},"asset":{"contract_name":"hello","asset_name":"asset-name","contract_address":"STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"}},{"type":"fungible","condition_code":"sent_greater_than","amount":"123456","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"},"asset":{"contract_name":"hello-ft","asset_name":"asset-name-ft","contract_address":"STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"}},{"type":"stx","condition_code":"sent_less_than","amount":"36723458","principal":{"type_id":"principal_standard","address":"ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"}}],"contract_call":{"contract_id":"ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world","function_name":"fn-name"},"events":[]}'
-    );
+
+    const expectedResp = {
+      block_hash: 'ff',
+      block_height: 123,
+      burn_block_time: 345,
+      canonical: true,
+      tx_id: 'c3e2fabaf7017fa2f6967db4f21be4540fdeae2d593af809c18a6adf369bfb03',
+      tx_index: 2,
+      tx_status: 'success',
+      tx_type: 'contract_call',
+      fee_rate: '200',
+      sender_address: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
+      sponsored: false,
+      post_condition_mode: 'deny',
+      post_conditions: [
+        {
+          type: 'non_fungible',
+          condition_code: 'not_sent',
+          principal: {
+            type_id: 'principal_standard',
+            address: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR',
+          },
+          asset: {
+            contract_name: 'hello',
+            asset_name: 'asset-name',
+            contract_address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
+          },
+          asset_value: { hex: '0x020000000b61737365742d76616c7565', repr: '"asset-value"' },
+        },
+        {
+          type: 'fungible',
+          condition_code: 'sent_greater_than',
+          amount: '123456',
+          principal: {
+            type_id: 'principal_standard',
+            address: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR',
+          },
+          asset: {
+            contract_name: 'hello-ft',
+            asset_name: 'asset-name-ft',
+            contract_address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
+          },
+        },
+        {
+          type: 'stx',
+          condition_code: 'sent_less_than',
+          amount: '36723458',
+          principal: {
+            type_id: 'principal_standard',
+            address: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR',
+          },
+        },
+      ],
+      contract_call: {
+        contract_id: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world',
+        function_name: 'fn-name',
+        function_signature: '(define-public (fn-name (arg1 int)))',
+        function_args: [
+          { hex: '0x000000000000000000000000000000022c', repr: '556', name: 'arg1', type: 'int' },
+        ],
+      },
+      events: [],
+    };
     expect(txQuery.result).toEqual(expectedResp);
   });
 });


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/101

Contract-call tx response objects now include more function data:
* Function signature (the Clarity function repr string)
* Function arg names and type repr strings

Examples:
```js
contract_call: {
  contract_id: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world',
  function_name: 'fn-name',
  function_signature: '(define-public (fn-name (arg1 int)))',
  function_args: [
    {
      hex: '0x000000000000000000000000000000022c',
      repr: '556',
      name: 'arg1',
      type: 'int',
    },
  ],
},
```

```js
contract_call: {
  contract_id: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.hello-world-contract',
  function_name: 'set-value',
  function_signature: '(define-public (set-value (key (buff 32)) (value (buff 32))))',
  function_args: [
    {
      hex: '0x0200000006776572776572',
      repr: '"werwer"',
      name: 'key',
      type: '(buff 32)',
    },
    {
      hex: '0x020000000c727479727479727479727479',
      repr: '"rtyrtyrtyrty"',
      name: 'value',
      type: '(buff 32)',
    },
  ],
},
```