### PR TITLE
fix url for /contract/ to be /sidecar/v1/contract/ …

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -61,7 +61,7 @@ paths:
         404:
           description: Cannot find transaction of given ID
 
-  /contract/{contract_id}:
+  /sidecar/v1/contract/{contract_id}:
     get:
       summary: Contract by address
       operationId: get_contract_by_id


### PR DESCRIPTION
to match what happens at runtime, otherwise you get a 404.  It should be the same as /sidecar/v1/tx and /sidecar/v1/tx/{tx_id}