### PR TITLE
feat: add block list API limit and offset query

### DIFF
--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -3,14 +3,25 @@ import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import * as Bluebird from 'bluebird';
 import { DataStore } from '../../datastore/common';
 import { getBlockFromDataStore } from '../controllers/db-controller';
-import { timeout, waiter } from '../../helpers';
+import { timeout, waiter, has0xPrefix } from '../../helpers';
 import { validate } from '../validate';
+import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
+
+const MAX_BLOCKS_PER_REQUEST = 30;
+
+const parseBlockQueryLimit = parseLimitQuery({
+  maxItems: MAX_BLOCKS_PER_REQUEST,
+  errorMsg: '`limit` must be equal to or less than ' + MAX_BLOCKS_PER_REQUEST,
+});
 
 export function createBlockRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
   router.getAsync('/', async (req, res) => {
-    const blocks = await db.getBlocks();
+    const limit = parseBlockQueryLimit(req.query.limit ?? 20);
+    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+
+    const blocks = await db.getBlocks({ offset, limit });
     // TODO: fix duplicate pg queries
     const result = await Bluebird.mapSeries(blocks.results, async block => {
       const blockQuery = await getBlockFromDataStore(block.block_hash, db);
@@ -26,6 +37,11 @@ export function createBlockRouter(db: DataStore): RouterWithAsync {
 
   router.getAsync('/:block_hash', async (req, res) => {
     const { block_hash } = req.params;
+
+    if (!has0xPrefix(block_hash)) {
+      return res.redirect('/sidecar/v1/block/0x' + block_hash);
+    }
+
     const block = await getBlockFromDataStore(block_hash, db);
     if (!block.found) {
       res.status(404).json({ error: `cannot find block by hash ${block_hash}` });

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -182,7 +182,10 @@ export interface DataStoreUpdateData {
 
 export interface DataStore extends DataStoreEventEmitter {
   getBlock(blockHash: string): Promise<{ found: true; result: DbBlock } | { found: false }>;
-  getBlocks(count?: number): Promise<{ results: DbBlock[] }>;
+  getBlocks(args: {
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbBlock[]; total: number }>;
   getBlockTxs(blockHash: string): Promise<{ results: string[] }>;
 
   getTx(txId: string): Promise<{ found: true; result: DbTx } | { found: false }>;


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/120

* Adds pagination support to the list-blocks API endpoint
* Latest 20 blocks are returned by default