### PR TITLE
Include tx failed status code

### DIFF
--- a/docs/entities/transactions/transaction-status.schema.json
+++ b/docs/entities/transactions/transaction-status.schema.json
@@ -3,5 +3,5 @@
   "title": "TransactionStatus",
   "description": "All states a transaction can have",
   "type": "string",
-  "enum": ["success", "pending", "failed"]
+  "enum": ["success", "pending", "abort_by_response", "abort_by_post_condition"]
 }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -380,7 +380,7 @@ export interface CoinbaseTransaction {
 /**
  * All states a transaction can have
  */
-export type TransactionStatus = "success" | "pending" | "failed";
+export type TransactionStatus = "success" | "pending" | "abort_by_response" | "abort_by_post_condition";
 
 /**
  * String literal of all Stacks 2.0 transaction types

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -107,7 +107,7 @@ export async function getBlockFromDataStore(
     return { found: false };
   }
   const dbBlock = blockQuery.result;
-  const txIds = await db.getBlockTxs(blockHash);
+  const txIds = await db.getBlockTxs(dbBlock.index_block_hash);
 
   const apiBlock: Block = {
     canonical: dbBlock.canonical,

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -57,8 +57,10 @@ function getTxStatusString(txStatus: DbTxStatus): Transaction['tx_status'] {
       return 'pending';
     case DbTxStatus.Success:
       return 'success';
-    case DbTxStatus.Failed:
-      return 'failed';
+    case DbTxStatus.AbortByResponse:
+      return 'abort_by_response';
+    case DbTxStatus.AbortByPostCondition:
+      return 'abort_by_post_condition';
     default:
       throw new Error(`Unexpected DbTxStatus: ${txStatus}`);
   }

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -186,7 +186,7 @@ export interface DataStore extends DataStoreEventEmitter {
     limit: number;
     offset: number;
   }): Promise<{ results: DbBlock[]; total: number }>;
-  getBlockTxs(blockHash: string): Promise<{ results: string[] }>;
+  getBlockTxs(indexBlockHash: string): Promise<{ results: string[] }>;
 
   getTx(txId: string): Promise<{ found: true; result: DbTx } | { found: false }>;
   getTxList(args: { limit: number; offset: number }): Promise<{ results: DbTx[]; total: number }>;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -124,9 +124,9 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     return Promise.resolve({ results, total: blockList.length });
   }
 
-  getBlockTxs(blockHash: string) {
+  getBlockTxs(indexBlockHash: string) {
     const results = [...this.txs.values()]
-      .filter(tx => tx.entry.block_hash === blockHash)
+      .filter(tx => tx.entry.index_block_hash === indexBlockHash)
       .map(tx => tx.entry.tx_id);
     return Promise.resolve({ results: results });
   }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -448,14 +448,14 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { results: parsed, total: total.rows[0].count } as const;
   }
 
-  async getBlockTxs(blockHash: string) {
+  async getBlockTxs(indexBlockHash: string) {
     const result = await this.pool.query<{ tx_id: Buffer; tx_index: number }>(
       `
       SELECT tx_id, tx_index
       FROM txs
-      WHERE block_hash = $1
+      WHERE index_block_hash = $1
       `,
-      [hexToBuffer(blockHash)]
+      [hexToBuffer(indexBlockHash)]
     );
     const txIds = result.rows.sort(tx => tx.tx_index).map(tx => bufferToHexPrefixString(tx.tx_id));
     return { results: txIds };

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -112,10 +112,12 @@ export type CoreNodeEvent =
   | NftTransferEvent
   | NftMintEvent;
 
+export type CoreNodeTxStatus = 'success' | 'abort_by_response' | 'abort_by_post_condition';
+
 export interface CoreNodeTxMessage {
   raw_tx: string;
   result: NonStandardClarityValue;
-  success: boolean;
+  status: CoreNodeTxStatus;
   txid: string;
   tx_index: number;
   contract_abi: ClarityAbi | null;

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -45,7 +45,7 @@ describe('api tests', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
-      index_block_hash: '0x3434',
+      index_block_hash: block.index_block_hash,
       block_hash: block.block_hash,
       block_height: 68456,
       burn_block_time: 2837565,

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -71,27 +71,11 @@ describe('postgres datastore', () => {
     const blockQuery = await db.getBlock(block.block_hash);
     assert(blockQuery.found);
     expect(blockQuery.result).toEqual(block);
-  });
-
-  test('pg block store and retrieve', async () => {
-    const block: DbBlock = {
-      block_hash: '0x1234',
-      index_block_hash: '0xdeadbeef',
-      parent_block_hash: '0xff0011',
-      parent_microblock: '0x9876',
-      block_height: 1235,
-      burn_block_time: 94869286,
-      canonical: true,
-    };
-    await db.updateBlock(client, block);
-    const blockQuery = await db.getBlock(block.block_hash);
-    assert(blockQuery.found);
-    expect(blockQuery.result).toEqual(block);
 
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
-      index_block_hash: '0x3434',
+      index_block_hash: block.index_block_hash,
       block_hash: block.block_hash,
       block_height: 68456,
       burn_block_time: 2837565,
@@ -106,7 +90,7 @@ describe('postgres datastore', () => {
       origin_hash_mode: 1,
     };
     await db.updateTx(client, tx);
-    const blockTxs = await db.getBlockTxs(block.block_hash);
+    const blockTxs = await db.getBlockTxs(block.index_block_hash);
     expect(blockTxs.results).toHaveLength(1);
     expect(blockTxs.results[0]).toBe('0x1234');
   });


### PR DESCRIPTION
Reference: https://github.com/blockstack/stacks-blockchain/pull/1612
Closes: https://github.com/blockstack/stacks-blockchain-sidecar/issues/97

The `tx_status` field is now one of the following values: `success`, `abort_by_response`, or `abort_by_post_condition`.

Note that `failed` is no longer a possible value. 

See https://github.com/blockstack/stacks-blockchain/pull/1612 for description of the abort value meanings. 