### PR TITLE
feat: ability to filter tx list by types

### DIFF
--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -13,6 +13,7 @@ import {
   ContractCallTransaction,
   TransactionEvent,
   Block,
+  TransactionType,
 } from '@blockstack/stacks-blockchain-sidecar-types';
 
 import {
@@ -34,7 +35,22 @@ import { BufferReader } from '../../binary-reader';
 import { serializePostCondition, serializePostConditionMode } from '../serializers/post-conditions';
 import { DbSmartContractEvent, DbFtEvent, DbNftEvent } from '../../datastore/common';
 
-function getTxTypeString(typeId: DbTxTypeId): Transaction['tx_type'] {
+export function parseTxTypeStrings(values: string[]): TransactionType[] {
+  return values.map(v => {
+    switch (v) {
+      case 'contract_call':
+      case 'smart_contract':
+      case 'token_transfer':
+      case 'coinbase':
+      case 'poison_microblock':
+        return v;
+      default:
+        throw new Error(`Unexpected tx type: ${JSON.stringify(v)}`);
+    }
+  });
+}
+
+export function getTxTypeString(typeId: DbTxTypeId): Transaction['tx_type'] {
   switch (typeId) {
     case DbTxTypeId.TokenTransfer:
       return 'token_transfer';
@@ -48,6 +64,23 @@ function getTxTypeString(typeId: DbTxTypeId): Transaction['tx_type'] {
       return 'coinbase';
     default:
       throw new Error(`Unexpected DbTxTypeId: ${typeId}`);
+  }
+}
+
+export function getTxTypeId(typeString: Transaction['tx_type']): DbTxTypeId {
+  switch (typeString) {
+    case 'token_transfer':
+      return DbTxTypeId.TokenTransfer;
+    case 'smart_contract':
+      return DbTxTypeId.SmartContract;
+    case 'contract_call':
+      return DbTxTypeId.ContractCall;
+    case 'poison_microblock':
+      return DbTxTypeId.PoisonMicroblock;
+    case 'coinbase':
+      return DbTxTypeId.Coinbase;
+    default:
+      throw new Error(`Unexpected tx type string: ${typeString}`);
   }
 }
 

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -10,6 +10,7 @@ import {
 } from '../p2p/tx';
 import { c32address } from 'c32check';
 import { addressFromHashMode, addressToString } from '@blockstack/stacks-transactions';
+import { TransactionType } from '@blockstack/stacks-blockchain-sidecar-types';
 
 export interface DbBlock {
   block_hash: string;
@@ -189,7 +190,11 @@ export interface DataStore extends DataStoreEventEmitter {
   getBlockTxs(blockHash: string): Promise<{ results: string[] }>;
 
   getTx(txId: string): Promise<{ found: true; result: DbTx } | { found: false }>;
-  getTxList(args: { limit: number; offset: number }): Promise<{ results: DbTx[]; total: number }>;
+  getTxList(args: {
+    limit: number;
+    offset: number;
+    txTypeFilter: TransactionType[];
+  }): Promise<{ results: DbTx[]; total: number }>;
 
   getTxEvents(txId: string, indexBlockHash: string): Promise<{ results: DbEvent[] }>;
 

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -27,7 +27,10 @@ describe('api tests', () => {
 
   describe('getTxList()', () => {
     test('it returns object', async () => {
-      expect(await db.getTxList({ limit: 10, offset: 0 })).toEqual({ results: [], total: 0 });
+      expect(await db.getTxList({ limit: 10, offset: 0, txTypeFilter: [] })).toEqual({
+        results: [],
+        total: 0,
+      });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/98

The recent transaction list API can use query param arrays to filter by type. The Express query param array formats are supported. Example usage:

* `/sidecar/v1/tx?type=token_transfer`
* `/sidecar/v1/tx?type=contract_call&type=smart_contract`
* `/sidecar/v1/tx?type[]=contract_call&type[]=smart_contract`