### PR TITLE
Feat/stx addr api

### DIFF
--- a/docs/entities/transaction-events/transaction-event-fungible-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-fungible-asset.schema.json
@@ -17,7 +17,7 @@
         "asset": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["asset_event_type", "asset_id", "sender", "amount"],
+          "required": ["asset_event_type", "asset_id", "sender", "recipient", "amount"],
           "properties": {
             "asset_event_type": {
               "type": "string"
@@ -26,6 +26,9 @@
               "type": "string"
             },
             "sender": {
+              "type": "string"
+            },
+            "recipient": {
               "type": "string"
             },
             "amount": {

--- a/docs/entities/transaction-events/transaction-event-non-fungible-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-non-fungible-asset.schema.json
@@ -17,7 +17,7 @@
         "asset": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["asset_event_type", "asset_id", "sender", "value"],
+          "required": ["asset_event_type", "asset_id", "sender", "recipient", "value"],
           "properties": {
             "asset_event_type": {
               "type": "string"
@@ -26,6 +26,9 @@
               "type": "string"
             },
             "sender": {
+              "type": "string"
+            },
+            "recipient": {
               "type": "string"
             },
             "value": {

--- a/docs/entities/transactions/transaction-0-token-transfer.schema.json
+++ b/docs/entities/transactions/transaction-0-token-transfer.schema.json
@@ -9,17 +9,11 @@
     },
     {
       "type": "object",
-      "required": ["tx_type", "token_transfer", "events"],
+      "required": ["tx_type", "token_transfer"],
       "properties": {
         "tx_type": {
           "type": "string",
           "enum": ["token_transfer"]
-        },
-        "events": {
-          "type": "array",
-          "items": {
-            "$ref": "../transaction-events/transaction-event.schema.json"
-          }
         },
         "token_transfer": {
           "type": "object",

--- a/docs/entities/transactions/transaction-0-token-transfer.schema.json
+++ b/docs/entities/transactions/transaction-0-token-transfer.schema.json
@@ -9,11 +9,17 @@
     },
     {
       "type": "object",
-      "required": ["tx_type", "token_transfer"],
+      "required": ["tx_type", "token_transfer", "events"],
       "properties": {
         "tx_type": {
           "type": "string",
           "enum": ["token_transfer"]
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "../transaction-events/transaction-event.schema.json"
+          }
         },
         "token_transfer": {
           "type": "object",

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -131,6 +131,7 @@ export interface TransactionEventFungibleAsset {
     asset_event_type: string;
     asset_id: string;
     sender: string;
+    recipient: string;
     amount: string;
   };
 }
@@ -142,6 +143,7 @@ export interface TransactionEventNonFungibleAsset {
     asset_event_type: string;
     asset_id: string;
     sender: string;
+    recipient: string;
     value: {
       hex: string;
       repr: string;
@@ -214,6 +216,7 @@ export interface TokenTransferTransaction {
   sponsored: boolean;
   post_condition_mode: PostConditionMode;
   tx_type: "token_transfer";
+  events: TransactionEvent[];
   token_transfer: {
     recipient_address: string;
     /**

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -214,7 +214,6 @@ export interface TokenTransferTransaction {
   sponsored: boolean;
   post_condition_mode: PostConditionMode;
   tx_type: "token_transfer";
-  events: TransactionEvent[];
   token_transfer: {
     recipient_address: string;
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8421,8 +8421,8 @@
       }
     },
     "@blockstack/stacks-transactions": {
-      "version": "github:blockstack/stacks-transactions-js#eee0518ee7bdb3869554433f94a14ae7f7ab8ce8",
-      "from": "github:blockstack/stacks-transactions-js#eee0518ee7bdb3869554433f94a14ae7f7ab8ce8",
+      "version": "github:blockstack/stacks-transactions-js#f5fd7c05188df67705504679d290fb684c2ee988",
+      "from": "github:blockstack/stacks-transactions-js#f5fd7c05188df67705504679d290fb684c2ee988",
       "requires": {
         "@types/bn.js": "^4.11.6",
         "@types/elliptic": "^6.4.12",
@@ -9146,9 +9146,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.152",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.152.tgz",
-      "integrity": "sha512-Vwf9YF2x1GE3WNeUMjT5bTHa2DqgUo87ocdgTScupY2JclZ5Nn7W2RLM/N0+oreexUk8uaVugR81NnTY/jNNXg=="
+      "version": "4.14.154",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.154.tgz",
+      "integrity": "sha512-VoDZIJmg3P8vPEnTldLvgA+q7RkIbVkbYX4k0cAVFzGAOQwUehVgRHgIr2/wepwivDst/rVRqaiBSjCXRnoWwQ=="
     },
     "@types/mime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:integrated": "npm run generate:schemas && npm run devenv:build && concurrently npm:dev npm:devenv:deploy",
     "test": "cross-env NODE_ENV=development jest --config ./jest.config.js --coverage",
     "test:watch": "cross-env NODE_ENV=development jest --config ./jest.config.js --watch",
-    "test:integration": "npm run devenv:deploy -- -d && cross-env NODE_ENV=development jest --config ./jest.config.js --coverage; npm run devenv:stop",
+    "test:integration": "npm run devenv:deploy -- -d && cross-env NODE_ENV=development jest --config ./jest.config.js --coverage --no-cache; npm run devenv:stop",
     "build": "rimraf ./lib && tsc",
     "start": "node ./lib/index.js",
     "lint": "npm run lint:eslint && npm run lint:prettier",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.1",
     "@awaitjs/express": "^0.5.1",
     "@blockstack/stacks-blockchain-sidecar-types": "file:docs",
-    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#eee0518ee7bdb3869554433f94a14ae7f7ab8ce8",
+    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#f5fd7c05188df67705504679d290fb684c2ee988",
     "big-integer": "^1.6.48",
     "bitcoinjs-lib": "^5.1.7",
     "bluebird": "^3.7.2",

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -12,6 +12,7 @@ import { createContractRouter } from './routes/contract';
 import { createCoreNodeRpcProxyRouter } from './routes/core-node-rpc-proxy';
 import { createBlockRouter } from './routes/block';
 import { createFaucetRouter } from './routes/faucets';
+import { createAddressRouter } from './routes/address';
 import { logger } from '../helpers';
 
 export async function startApiServer(
@@ -52,6 +53,7 @@ export async function startApiServer(
       router.use('/tx', createTxRouter(datastore));
       router.use('/block', createBlockRouter(datastore));
       router.use('/contract', createContractRouter(datastore));
+      router.use('/address', createAddressRouter(datastore));
       router.use('/debug', createDebugRouter(datastore));
       router.use('/status', (req, res) => res.status(200).json({ status: 'ready' }));
       router.use('/faucets', createFaucetRouter(datastore));

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -64,7 +64,7 @@ export function createAddressRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
   // get balances for STX, FTs, and counts for NFTs
-  router.getAsync('/:stx_address/balance', async (req, res) => {
+  router.getAsync('/:stx_address/balances', async (req, res) => {
     const stxAddress = req.params['stx_address'];
     if (!isValidStxAddress(stxAddress)) {
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -1,0 +1,96 @@
+import * as express from 'express';
+import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { DataStore } from '../../datastore/common';
+import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
+import { c32addressDecode } from 'c32check';
+
+const MAX_TX_PER_REQUEST = 50;
+const MAX_ASSETS_PER_REQUEST = 50;
+
+const parseTxQueryLimit = parseLimitQuery({
+  maxItems: MAX_TX_PER_REQUEST,
+  errorMsg: '`limit` must be equal to or less than ' + MAX_TX_PER_REQUEST,
+});
+
+const parseAssetsQueryLimit = parseLimitQuery({
+  maxItems: MAX_ASSETS_PER_REQUEST,
+  errorMsg: '`limit` must be equal to or less than ' + MAX_TX_PER_REQUEST,
+});
+
+function isValidStxAddress(stxAddress: string): boolean {
+  try {
+    c32addressDecode(stxAddress);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+// TODO: define this in json schema
+interface AddressBalanceResponse {
+  stx: {
+    balance: string;
+    total_sent: string;
+    total_received: string;
+  };
+  fungible_tokens: {
+    [name: string]: string;
+  };
+  non_fungible_tokens: {
+    [name: string]: number;
+  };
+}
+
+export function createAddressRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+
+  // get balances for STX, FTs, and counts for NFTs
+  router.getAsync('/:stx_address/balance', async (req, res) => {
+    const stxAddress = req.params['stx_address'];
+    if (!isValidStxAddress(stxAddress)) {
+      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+    }
+    // Get balance info for STX token
+    const { balance, totalSent, totalReceived } = await db.getStxBalance(stxAddress);
+    const result: AddressBalanceResponse = {
+      stx: {
+        balance: balance.toString(),
+        total_sent: totalSent.toString(),
+        total_received: totalReceived.toString(),
+      },
+      // TODO: implement fungible_tokens balance query
+      fungible_tokens: {},
+      // TODO: implement non_fungible_tokens count query
+      non_fungible_tokens: {},
+    };
+    res.json(result);
+  });
+
+  router.getAsync('/:stx_address/transactions', async (req, res) => {
+    // get recent txs associated (sender or receiver) with address
+    const stxAddress = req.params['stx_address'];
+    if (!isValidStxAddress(stxAddress)) {
+      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+    }
+
+    const limit = parseTxQueryLimit(req.query.limit ?? 20);
+    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+    // TODO: implement get recent address txs
+    await Promise.resolve();
+  });
+
+  router.getAsync('/:stx_address/assets', async (req, res) => {
+    // get recent asset event associated with address
+    const stxAddress = req.params['stx_address'];
+    if (!isValidStxAddress(stxAddress)) {
+      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+    }
+
+    const limit = parseAssetsQueryLimit(req.query.limit ?? 20);
+    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+    // TODO: implement get recent address asset events
+    await Promise.resolve();
+  });
+
+  return router;
+}

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -353,7 +353,7 @@ export function createDebugRouter(db: DataStore): RouterWithAsync {
   });
 
   router.postAsync('/faucet', async (req, res) => {
-    const address: string = `${req.query.address}` || `${req.body.address}`;
+    const address: string = req.query.address || req.body.addres;
     const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
     const lastRequest = await db.getSTXFaucetRequest(address);
 

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -337,7 +337,7 @@ export function createDebugRouter(db: DataStore): RouterWithAsync {
   });
 
   router.postAsync('/faucet', async (req, res) => {
-    const address: string = req.query.address || req.body.addres;
+    const address: string = req.query.address || req.body.address;
     const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
     const lastRequest = await db.getSTXFaucetRequest(address);
 

--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -12,7 +12,7 @@ export function createFaucetRouter(db: DataStore): RouterWithAsync {
   const faucetRequestQueue = new PQueue({ concurrency: 1 });
 
   router.postAsync('/btc', async (req, res) => {
-    const address: string = `${req.query.address}` || `${req.body.address}`;
+    const address: string = req.query.address || req.body.address;
     const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
     const lastRequest = await db.getBTCFaucetRequest(address);
 

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -116,6 +116,7 @@ export enum DbEventTypeId {
 export interface DbEventBase {
   event_index: number;
   tx_id: string;
+  tx_index: number;
   block_height: number;
   /** Set to `true` if entry corresponds to the canonical chain tip */
   canonical: boolean;
@@ -225,10 +226,16 @@ export interface DataStore extends DataStoreEventEmitter {
   ): Promise<{ found: true; result: DbFaucetRequest } | { found: false }>;
 
   getAddressTxs(args: {
-    address: string;
+    stxAddress: string;
     limit: number;
     offset: number;
   }): Promise<{ results: DbTx[]; total: number }>;
+
+  getAddressAssetEvents(args: {
+    stxAddress: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbEvent[]; total: number }>;
 
   insertFaucetRequest(faucetRequest: DbFaucetRequest): Promise<void>;
 }

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -205,6 +205,12 @@ export interface DataStore extends DataStoreEventEmitter {
 
   update(data: DataStoreUpdateData): Promise<void>;
 
+  getStxBalance(
+    stxAddress: string
+  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }>;
+  getFungibleTokenBalances(stxAddress: string): Promise<Map<string, bigint>>;
+  getNonFungibleTokenCounts(stxAddress: string): Promise<Map<string, bigint>>;
+
   getBTCFaucetRequest(
     address: string
   ): Promise<{ found: true; result: DbFaucetRequest } | { found: false }>;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -211,7 +211,9 @@ export interface DataStore extends DataStoreEventEmitter {
   getFungibleTokenBalances(
     stxAddress: string
   ): Promise<Map<string, { balance: bigint; totalSent: bigint; totalReceived: bigint }>>;
-  getNonFungibleTokenCounts(stxAddress: string): Promise<Map<string, bigint>>;
+  getNonFungibleTokenCounts(
+    stxAddress: string
+  ): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>>;
 
   getBTCFaucetRequest(
     address: string

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -208,7 +208,9 @@ export interface DataStore extends DataStoreEventEmitter {
   getStxBalance(
     stxAddress: string
   ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }>;
-  getFungibleTokenBalances(stxAddress: string): Promise<Map<string, bigint>>;
+  getFungibleTokenBalances(
+    stxAddress: string
+  ): Promise<Map<string, { balance: bigint; totalSent: bigint; totalReceived: bigint }>>;
   getNonFungibleTokenCounts(stxAddress: string): Promise<Map<string, bigint>>;
 
   getBTCFaucetRequest(

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -243,6 +243,20 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     return Promise.resolve({ found: true, result: entries[0].entry });
   }
 
+  getStxBalance(
+    stxAddress: string
+  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }> {
+    throw new Error('not yet implemented');
+  }
+
+  getFungibleTokenBalances(_stxAddress: string): Promise<Map<string, bigint>> {
+    throw new Error('not yet implemented');
+  }
+
+  getNonFungibleTokenCounts(_stxAddress: string): Promise<Map<string, bigint>> {
+    throw new Error('not yet implemented');
+  }
+
   insertFaucetRequest(faucetRequest: DbFaucetRequest) {
     this.faucetRequests.set(faucetRequest.address, {
       entry: { ...faucetRequest },

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -261,6 +261,18 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     throw new Error('not yet implemented');
   }
 
+  getAddressTxs({
+    address,
+    limit,
+    offset,
+  }: {
+    address: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbTx[]; total: number }> {
+    throw new Error('not yet implemented');
+  }
+
   insertFaucetRequest(faucetRequest: DbFaucetRequest) {
     this.faucetRequests.set(faucetRequest.address, {
       entry: { ...faucetRequest },

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -11,6 +11,7 @@ import {
   DataStoreEventEmitter,
   DataStoreUpdateData,
   DbFaucetRequest,
+  DbEvent,
 } from './common';
 import { logger } from '../helpers';
 import { TransactionType } from '@blockstack/stacks-blockchain-sidecar-types';
@@ -262,14 +263,26 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   }
 
   getAddressTxs({
-    address,
+    stxAddress,
     limit,
     offset,
   }: {
-    address: string;
+    stxAddress: string;
     limit: number;
     offset: number;
   }): Promise<{ results: DbTx[]; total: number }> {
+    throw new Error('not yet implemented');
+  }
+
+  getAddressAssetEvents({
+    stxAddress,
+    limit,
+    offset,
+  }: {
+    stxAddress: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbEvent[]; total: number }> {
     throw new Error('not yet implemented');
   }
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -249,7 +249,9 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     throw new Error('not yet implemented');
   }
 
-  getFungibleTokenBalances(_stxAddress: string): Promise<Map<string, bigint>> {
+  getFungibleTokenBalances(
+    stxAddress: string
+  ): Promise<Map<string, { balance: bigint; totalSent: bigint; totalReceived: bigint }>> {
     throw new Error('not yet implemented');
   }
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -255,7 +255,9 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     throw new Error('not yet implemented');
   }
 
-  getNonFungibleTokenCounts(_stxAddress: string): Promise<Map<string, bigint>> {
+  getNonFungibleTokenCounts(
+    stxAddress: string
+  ): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>> {
     throw new Error('not yet implemented');
   }
 

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -80,6 +80,7 @@ async function handleClientMessage(msg: CoreNodeMessage, db: DataStore): Promise
     const dbEvent: DbEventBase = {
       event_index: eventIndex,
       tx_id: event.txid,
+      tx_index: dbTx.tx.tx_index,
       block_height: parsedMsg.block_height,
       canonical: true,
     };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -133,6 +133,17 @@ export function logError(message: string, error?: Error) {
   }
 }
 
+export function formatMapToObject<TKey extends string, TValue, TFormatted>(
+  map: Map<TKey, TValue>,
+  formatter: (value: TValue) => TFormatted
+): Record<TKey, TFormatted> {
+  const obj = {} as Record<TKey, TFormatted>;
+  for (const [key, value] of map) {
+    obj[key] = formatter(value);
+  }
+  return obj;
+}
+
 export function parsePort(portVal: number | string | undefined): number | undefined {
   if (portVal === undefined) {
     return undefined;

--- a/src/migrations/1584619633448_txs.ts
+++ b/src/migrations/1584619633448_txs.ts
@@ -92,6 +92,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('txs', 'block_height');
   pgm.createIndex('txs', 'canonical');
   pgm.createIndex('txs', 'sender_address');
+  pgm.createIndex('txs', 'token_transfer_recipient_address');
 
   pgm.addConstraint('txs', 'unique_tx_id_index_block_hash', `UNIQUE(tx_id, index_block_hash)`);
 

--- a/src/migrations/1588252682585_stx_events.ts
+++ b/src/migrations/1588252682585_stx_events.ts
@@ -14,6 +14,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       notNull: true,
       type: 'bytea',
     },
+    tx_index: {
+      type: 'smallint',
+      notNull: true,
+    },
     block_height: {
       type: 'integer',
       notNull: true,

--- a/src/migrations/1588256295395_ft_events.ts
+++ b/src/migrations/1588256295395_ft_events.ts
@@ -14,6 +14,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       notNull: true,
       type: 'bytea',
     },
+    tx_index: {
+      type: 'smallint',
+      notNull: true,
+    },
     block_height: {
       type: 'integer',
       notNull: true,

--- a/src/migrations/1588261750265_nft_events.ts
+++ b/src/migrations/1588261750265_nft_events.ts
@@ -14,6 +14,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       notNull: true,
       type: 'bytea',
     },
+    tx_index: {
+      type: 'smallint',
+      notNull: true,
+    },
     block_height: {
       type: 'integer',
       notNull: true,

--- a/src/migrations/1588266401242_contract_logs.ts
+++ b/src/migrations/1588266401242_contract_logs.ts
@@ -14,6 +14,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       notNull: true,
       type: 'bytea',
     },
+    tx_index: {
+      type: 'smallint',
+      notNull: true,
+    },
     block_height: {
       type: 'integer',
       notNull: true,

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -376,6 +376,11 @@ describe('postgres datastore', () => {
       createStxTx('addrA', 'addrB', 40, false),
       createStxTx('addrB', 'addrC', 15),
       createStxTx('addrA', 'addrC', 35),
+      createStxTx('addrE', 'addrF', 2),
+      createStxTx('addrE', 'addrF', 2),
+      createStxTx('addrE', 'addrF', 2),
+      createStxTx('addrE', 'addrF', 2),
+      createStxTx('addrE', 'addrF', 2),
     ];
     for (const tx of txs) {
       await db.updateTx(client, tx);
@@ -385,6 +390,10 @@ describe('postgres datastore', () => {
     const addrBResult = await db.getAddressTxs({ address: 'addrB', limit: 3, offset: 0 });
     const addrCResult = await db.getAddressTxs({ address: 'addrC', limit: 3, offset: 0 });
     const addrDResult = await db.getAddressTxs({ address: 'addrD', limit: 3, offset: 0 });
+    const addrEResult = await db.getAddressTxs({ address: 'addrE', limit: 3, offset: 0 });
+    const addrEResultP2 = await db.getAddressTxs({ address: 'addrE', limit: 3, offset: 3 });
+
+    expect(addrEResult.total).toBe(5);
 
     const mapAddrTxResults = (txs: DbTx[]) => {
       return txs.map(tx => ({
@@ -447,6 +456,40 @@ describe('postgres datastore', () => {
         token_transfer_recipient_address: 'addrC',
         tx_id: '0x12340005',
         tx_index: 5,
+      },
+    ]);
+    expect(mapAddrTxResults(addrEResult.results)).toEqual([
+      {
+        sender_address: 'addrE',
+        token_transfer_recipient_address: 'addrF',
+        tx_id: '0x12340011',
+        tx_index: 11,
+      },
+      {
+        sender_address: 'addrE',
+        token_transfer_recipient_address: 'addrF',
+        tx_id: '0x12340010',
+        tx_index: 10,
+      },
+      {
+        sender_address: 'addrE',
+        token_transfer_recipient_address: 'addrF',
+        tx_id: '0x12340009',
+        tx_index: 9,
+      },
+    ]);
+    expect(mapAddrTxResults(addrEResultP2.results)).toEqual([
+      {
+        sender_address: 'addrE',
+        token_transfer_recipient_address: 'addrF',
+        tx_id: '0x12340008',
+        tx_index: 8,
+      },
+      {
+        sender_address: 'addrE',
+        token_transfer_recipient_address: 'addrF',
+        tx_id: '0x12340007',
+        tx_index: 7,
       },
     ]);
     expect(mapAddrTxResults(addrDResult.results)).toEqual([]);


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/113

This PR provides several stx address API endpoints which can be used to create a useful front-end page that displays address details:
* Balance (with total sent and received) for STX
* Balances for all fungible-tokens that the address has ever sent or received
* Ownership counts for all non-fungible-tokens that the address has ever sent or received
* List of latest transactions associated with the address, w/ pagination support
* List of latest asset events (transfers, mints, burns) associated with the address, w/ pagination support

The new endpoints are:
* `/sidecar/v1/address/<stx address>/balances` - STX, FT, and NFT balances/counts
* `/sidecar/v1/address/<stx address>/transactions` - recent transactions (limit-offset params supported)
* `/sidecar/v1/address/<stx address>/assets` - recent asset events (limit-offset params supported)

Note: the API schemas/types for the new responses are still a WIP.


This PR also fixes the critical bugs:
* Several fields displayed an incorrect stx address (the pubkeyhash was being double-hashed).
* Missing `recipient` address field in NFT and FT asset events.
* Regression in BTC and STX faucet where address could not be specified as form data.