### PR TITLE
Feat/permissive faucet

### DIFF
--- a/docker-compose.dev.stacks-blockchain.yml
+++ b/docker-compose.dev.stacks-blockchain.yml
@@ -6,7 +6,7 @@ services:
     command: stacks-node start --config=/app/config/Stacks-dev.toml
     restart: on-failure
     environment:
-      STACKS_EVENT_OBSERVER: http://host.docker.internal:3700
+      STACKS_EVENT_OBSERVER: http://host.docker.internal:3700/
       NOP_BLOCKSTACK_DEBUG: 1
     ports:
       - "20443:20443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     command: stacks-node start --config=/app/config/Stacks-follower.toml
     restart: on-failure
     environment:
-      STACKS_EVENT_OBSERVER: http://sidecar:3700
+      STACKS_EVENT_OBSERVER: http://sidecar:3700/
       XBLOCKSTACK_DEBUG: 1
       RUST_BACKTRACE: 1
     ports:

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development STACKS_SIDECAR_DB=memory ts-node src/index.ts",
-    "dev:watch": "cross-env NODE_ENV=development STACKS_SIDECAR_DB=memory nodemon -e ts -x 'ts-node src/index.ts'",
+    "dev": "cross-env NODE_ENV=development STACKS_SIDECAR_DB=pg ts-node src/index.ts",
+    "dev:watch": "cross-env NODE_ENV=development STACKS_SIDECAR_DB=pg nodemon -e ts -x 'ts-node src/index.ts'",
     "dev:integrated": "npm run devenv:build && concurrently npm:dev npm:devenv:deploy",
     "test": "cross-env NODE_ENV=development jest --config ./jest.config.js --coverage",
     "test:watch": "cross-env NODE_ENV=development jest --config ./jest.config.js --watch",

--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -2,9 +2,13 @@ import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import * as btc from 'bitcoinjs-lib';
 import PQueue from 'p-queue';
+import * as BN from 'bn.js';
+import { makeSTXTokenTransfer } from '@blockstack/stacks-transactions';
 import { makeBtcFaucetPayment, getBtcBalance } from '../../btc-faucet';
 import { DataStore, DbFaucetRequestCurrency } from '../../datastore/common';
 import { logger } from '../../helpers';
+import { testnetKeys, GetStacksTestnetNetwork } from './debug';
+import { StacksCoreRpcClient } from '../../core-rpc/client';
 
 export function createFaucetRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
@@ -55,6 +59,61 @@ export function createFaucetRouter(db: DataStore): RouterWithAsync {
     const { address } = req.params;
     const balance = await getBtcBalance(btc.networks.regtest, address);
     res.json({ balance });
+  });
+
+  const stxFaucetRequestQueue = new PQueue({ concurrency: 1 });
+
+  router.postAsync('/stx', async (req, res) => {
+    await stxFaucetRequestQueue.add(async () => {
+      const address: string = req.query.address || req.body.address;
+      const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+      const lastRequests = await db.getSTXFaucetRequests(address);
+
+      const privateKey = process.env.FAUCET_PRIVATE_KEY || testnetKeys[0].secretKey;
+
+      // Guard condition: requests are limited to 5 times per 5 minutes.
+      // Only based on address for now, but we're keeping the IP in case
+      // we want to escalate and implement a per IP policy
+      const now = Date.now();
+      const window = 5 * 60 * 1000; // 5 minutes
+      const requestsInWindow = lastRequests.results
+        .map(r => now - r.occurred_at)
+        .filter(r => r <= window);
+      if (requestsInWindow.length >= 5) {
+        logger.warn(`STX faucet rate limit hit for address ${address}`);
+        res.status(429).json({
+          error: 'Too many requests',
+          success: false,
+        });
+        return;
+      }
+
+      const stxAmount = 500_000; // 0.5 STX
+      const tx = await makeSTXTokenTransfer({
+        recipient: address,
+        amount: new BN(stxAmount),
+        senderKey: privateKey,
+        network: GetStacksTestnetNetwork(),
+        memo: 'Faucet',
+      });
+
+      await db.insertFaucetRequest({
+        ip: `${ip}`,
+        address: address,
+        currency: DbFaucetRequestCurrency.STX,
+        occurred_at: now,
+      });
+
+      const hex = tx.serialize().toString('hex');
+      const serializedTx = tx.serialize();
+      const { txId } = await new StacksCoreRpcClient().sendTransaction(serializedTx);
+
+      res.json({
+        success: true,
+        txId,
+        txRaw: hex,
+      });
+    });
   });
 
   return router;

--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -4,51 +4,50 @@ import * as btc from 'bitcoinjs-lib';
 import PQueue from 'p-queue';
 import { makeBtcFaucetPayment, getBtcBalance } from '../../btc-faucet';
 import { DataStore, DbFaucetRequestCurrency } from '../../datastore/common';
+import { logger } from '../../helpers';
 
 export function createFaucetRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
   router.use(express.urlencoded({ extended: true }));
 
-  const faucetRequestQueue = new PQueue({ concurrency: 1 });
+  const btcFaucetRequestQueue = new PQueue({ concurrency: 1 });
 
   router.postAsync('/btc', async (req, res) => {
-    const address: string = req.query.address || req.body.address;
-    const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-    const lastRequest = await db.getBTCFaucetRequest(address);
+    await btcFaucetRequestQueue.add(async () => {
+      const address: string = req.query.address || req.body.address;
+      const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
 
-    // Guard condition: 6 hours between now and the last request, if any.
-    // Only based on address for now, but we're keeping the IP in case
-    // we want to escalate and implement a per IP policy
-    const now = new Date().getTime();
-    if (lastRequest.found && lastRequest.result.occurred_at) {
-      const lastOccurence = new Date().setTime(parseInt(lastRequest.result.occurred_at));
-      const timeInterval = now - lastOccurence;
-      const sixHours = 6 * 60 * 60 * 1000;
-      if (timeInterval < sixHours) {
-        res.sendStatus(429);
-        res.json({
+      // Guard condition: requests are limited to 5 times per 5 minutes.
+      // Only based on address for now, but we're keeping the IP in case
+      // we want to escalate and implement a per IP policy
+      const lastRequests = await db.getBTCFaucetRequests(address);
+      const now = Date.now();
+      const window = 5 * 60 * 1000; // 5 minutes
+      const requestsInWindow = lastRequests.results
+        .map(r => now - r.occurred_at)
+        .filter(r => r <= window);
+      if (requestsInWindow.length >= 5) {
+        logger.warn(`BTC faucet rate limit hit for address ${address}`);
+        res.status(429).json({
           error: 'Too many requests',
           success: false,
         });
         return;
       }
-    }
 
-    const tx = await faucetRequestQueue.add(async () => {
-      return await makeBtcFaucetPayment(btc.networks.regtest, address, 0.5);
-    });
+      const tx = await makeBtcFaucetPayment(btc.networks.regtest, address, 0.5);
+      await db.insertFaucetRequest({
+        ip: `${ip}`,
+        address: address,
+        currency: DbFaucetRequestCurrency.BTC,
+        occurred_at: now,
+      });
 
-    await db.insertFaucetRequest({
-      ip: `${ip}`,
-      address: address,
-      currency: DbFaucetRequestCurrency.BTC,
-      occurred_at: now.toString(),
-    });
-
-    res.json({
-      txid: tx.txId,
-      raw_tx: tx.rawTx,
-      success: true,
+      res.json({
+        txid: tx.txId,
+        raw_tx: tx.rawTx,
+        success: true,
+      });
     });
   });
 

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -104,7 +104,7 @@ export interface DbFaucetRequest {
   currency: DbFaucetRequestCurrency;
   address: string;
   ip: string;
-  occurred_at: string;
+  occurred_at: number;
 }
 
 export enum DbEventTypeId {
@@ -218,13 +218,9 @@ export interface DataStore extends DataStoreEventEmitter {
     stxAddress: string
   ): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>>;
 
-  getBTCFaucetRequest(
-    address: string
-  ): Promise<{ found: true; result: DbFaucetRequest } | { found: false }>;
+  getBTCFaucetRequests(address: string): Promise<{ results: DbFaucetRequest[] }>;
 
-  getSTXFaucetRequest(
-    address: string
-  ): Promise<{ found: true; result: DbFaucetRequest } | { found: false }>;
+  getSTXFaucetRequests(address: string): Promise<{ results: DbFaucetRequest[] }>;
 
   getAddressTxs(args: {
     stxAddress: string;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -707,7 +707,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       currency: result.currency as DbFaucetRequestCurrency,
       address: result.address,
       ip: result.ip,
-      occurred_at: result.occurred_at,
+      occurred_at: parseInt(result.occurred_at),
     };
     return tx;
   }
@@ -1359,38 +1359,34 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     }
   }
 
-  async getBTCFaucetRequest(address: string) {
-    const result = await this.pool.query<FaucetRequestQueryResult>(
+  async getBTCFaucetRequests(address: string) {
+    const queryResult = await this.pool.query<FaucetRequestQueryResult>(
       `
       SELECT ip, address, currency, occurred_at
       FROM faucet_requests
       WHERE address = $1 AND currency = 'btc'
+      ORDER BY occurred_at DESC
+      LIMIT 5
       `,
       [address]
     );
-    if (result.rowCount === 0) {
-      return { found: false } as const;
-    }
-    const row = result.rows[0];
-    const faucetRequest = this.parseFaucetRequestQueryResult(row);
-    return { found: true, result: faucetRequest };
+    const results = queryResult.rows.map(r => this.parseFaucetRequestQueryResult(r));
+    return { results };
   }
 
-  async getSTXFaucetRequest(address: string) {
-    const result = await this.pool.query<FaucetRequestQueryResult>(
+  async getSTXFaucetRequests(address: string) {
+    const queryResult = await this.pool.query<FaucetRequestQueryResult>(
       `
       SELECT ip, address, currency, occurred_at
       FROM faucet_requests
       WHERE address = $1 AND currency = 'stx'
+      ORDER BY occurred_at DESC
+      LIMIT 5
       `,
       [address]
     );
-    if (result.rowCount === 0) {
-      return { found: false } as const;
-    }
-    const row = result.rows[0];
-    const faucetRequest = this.parseFaucetRequestQueryResult(row);
-    return { found: true, result: faucetRequest };
+    const results = queryResult.rows.map(r => this.parseFaucetRequestQueryResult(r));
+    return { results };
   }
 
   async close(): Promise<void> {

--- a/src/migrations/1589552602432_faucet_requests.ts
+++ b/src/migrations/1589552602432_faucet_requests.ts
@@ -19,7 +19,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       notNull: true,
     },
     occurred_at: {
-      type: 'string',
+      type: 'bigint',
       notNull: true,
     },
   });


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/116
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/107

BTC and STX faucet endpoints are now throttled at 5 times per 5 minutes for a given address.

The STX endpoint has been updated from `/sidecar/v1/debug/faucet` to `/sidecar/v1/faucets/stx` (to be consistent with the BTC endpoint at `/sidecar/v1/faucets/btc`). 

The legacy endpoint performs a `307 Redirect` to the new endpoint -- this should ensure the legacy endpoint still works for browsers, but some tools (like cURL) need to include the `follow redirects` flag in order to use the legacy endpoint. 

## Testing

This change is available in the mocknet deployment at `https://crashy-stacky.zone117x.com`

The BTC faucet request to legacy endpoint `https://crashy-stacky.zone117x.com/sidecar/v1/debug/faucet` should be tested to ensure it still works with the redirect to the new endpoint 