### PR TITLE
Feat/mempool txs

### DIFF
--- a/docs/entities/transactions/abstract-transaction.schema.json
+++ b/docs/entities/transactions/abstract-transaction.schema.json
@@ -3,12 +3,7 @@
   "description": "Abstract transaction. This schema makes up all properties common between all Stacks 2.0 transaction types",
   "type": "object",
   "required": [
-    "block_hash",
-    "block_height",
-    "burn_block_time",
-    "canonical",
     "tx_id",
-    "tx_index",
     "tx_status",
     "fee_rate",
     "sender_address",

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -195,15 +195,15 @@ export type TransactionEvent =
  * Describes representation of a Type-0 Stacks 2.0 transaction. https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-005-blocks-and-transactions.md#type-0-transferring-an-asset
  */
 export interface TokenTransferTransaction {
-  block_hash: string;
-  block_height: number;
+  block_hash?: string;
+  block_height?: number;
   /**
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
-  burn_block_time: number;
-  canonical: boolean;
+  burn_block_time?: number;
+  canonical?: boolean;
   tx_id: string;
-  tx_index: number;
+  tx_index?: number;
   tx_status: TransactionStatus;
   /**
    * Integer string (64-bit unsigned integer).
@@ -234,15 +234,15 @@ export interface TokenTransferTransaction {
  * Describes representation of a Type-1 Stacks 2.0 transaction. https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-005-blocks-and-transactions.md#type-1-instantiating-a-smart-contract
  */
 export interface SmartContractTransaction {
-  block_hash: string;
-  block_height: number;
+  block_hash?: string;
+  block_height?: number;
   /**
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
-  burn_block_time: number;
-  canonical: boolean;
+  burn_block_time?: number;
+  canonical?: boolean;
   tx_id: string;
-  tx_index: number;
+  tx_index?: number;
   tx_status: TransactionStatus;
   /**
    * Integer string (64-bit unsigned integer).
@@ -270,15 +270,15 @@ export interface SmartContractTransaction {
  * Describes representation of a Type 2 Stacks 2.0 transaction: Contract Call
  */
 export interface ContractCallTransaction {
-  block_hash: string;
-  block_height: number;
+  block_hash?: string;
+  block_height?: number;
   /**
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
-  burn_block_time: number;
-  canonical: boolean;
+  burn_block_time?: number;
+  canonical?: boolean;
   tx_id: string;
-  tx_index: number;
+  tx_index?: number;
   tx_status: TransactionStatus;
   /**
    * Integer string (64-bit unsigned integer).
@@ -313,15 +313,15 @@ export interface ContractCallTransaction {
  * Describes representation of a Type 3 Stacks 2.0 transaction: Poison Microblock
  */
 export interface PoisonMicroblockTransaction {
-  block_hash: string;
-  block_height: number;
+  block_hash?: string;
+  block_height?: number;
   /**
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
-  burn_block_time: number;
-  canonical: boolean;
+  burn_block_time?: number;
+  canonical?: boolean;
   tx_id: string;
-  tx_index: number;
+  tx_index?: number;
   tx_status: TransactionStatus;
   /**
    * Integer string (64-bit unsigned integer).
@@ -350,15 +350,15 @@ export interface PoisonMicroblockTransaction {
  * Describes representation of a Type 3 Stacks 2.0 transaction: Poison Microblock
  */
 export interface CoinbaseTransaction {
-  block_hash: string;
-  block_height: number;
+  block_hash?: string;
+  block_height?: number;
   /**
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
-  burn_block_time: number;
-  canonical: boolean;
+  burn_block_time?: number;
+  canonical?: boolean;
   tx_id: string;
-  tx_index: number;
+  tx_index?: number;
   tx_status: TransactionStatus;
   /**
    * Integer string (64-bit unsigned integer).

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-blockchain-sidecar-types",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "access": "public",
   "description": "TypeScript descriptions of Stacks 2.0 sidecar API entities",
   "main": "index.d.ts",

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -70,9 +70,9 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
       throw new Error('WebSocket stream not yet implemented');
     }
 
-    const dbTxUpdate = async (tx: DbTx): Promise<void> => {
+    const dbTxUpdate = async (txId: string): Promise<void> => {
       try {
-        const txQuery = await getTxFromDataStore(tx.tx_id, db);
+        const txQuery = await getTxFromDataStore(txId, db);
         if (!txQuery.found) {
           throw new Error('error in tx stream, tx not found');
         }
@@ -87,9 +87,9 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
     };
 
     // EventEmitters don't like being passed Promise functions so wrap the async handler
-    const onTxUpdate = (tx: DbTx): void => {
+    const onTxUpdate = (txId: string): void => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      dbTxUpdate(tx);
+      dbTxUpdate(txId);
     };
 
     const endWaiter = waiter();

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -86,6 +86,47 @@ export interface DbTx {
   coinbase_payload?: Buffer;
 }
 
+export interface DbMempoolTx {
+  tx_id: string;
+  tx_index: number;
+  type_id: DbTxTypeId;
+
+  status: DbTxStatus;
+  /** Set to `true` if entry corresponds to the canonical chain tip */
+  canonical: boolean;
+  post_conditions: Buffer;
+  /** u64 */
+  fee_rate: bigint;
+  sender_address: string;
+  /** u8 */
+  origin_hash_mode: number;
+  sponsored: boolean;
+
+  /** Only valid for `token_transfer` tx types. */
+  token_transfer_recipient_address?: string;
+  /** 64-bit unsigned integer. */
+  token_transfer_amount?: bigint;
+  /** Hex encoded arbitrary message, up to 34 bytes length (should try decoding to an ASCII string). */
+  token_transfer_memo?: Buffer;
+
+  /** Only valid for `contract_call` tx types */
+  contract_call_contract_id?: string;
+  contract_call_function_name?: string;
+  /** Hex encoded Clarity values. Undefined if function defines no args. */
+  contract_call_function_args?: Buffer;
+
+  /** Only valid for `smart_contract` tx types. */
+  smart_contract_contract_id?: string;
+  smart_contract_source_code?: string;
+
+  /** Only valid for `poison_microblock` tx types. */
+  poison_microblock_header_1?: Buffer;
+  poison_microblock_header_2?: Buffer;
+
+  /** Only valid for `coinbase` tx types. Hex encoded 32-bytes. */
+  coinbase_payload?: Buffer;
+}
+
 export interface DbSmartContract {
   tx_id: string;
   canonical: boolean;
@@ -207,6 +248,8 @@ export interface DataStore extends DataStoreEventEmitter {
   ): Promise<{ found: true; result: DbSmartContract } | { found: false }>;
 
   update(data: DataStoreUpdateData): Promise<void>;
+
+  // updateMempoolTx(args: { mempoolTx: DbMempoolTx }): Promise<void>;
 
   getStxBalance(
     stxAddress: string

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -872,8 +872,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       ]
     );
     if (result.rowCount !== 1) {
-      // TODO: handle insert conflicts
-      throw new Error('todo');
+      const errMsg = `A duplicate transaction was attempted to be inserted into the mempool_txs table: ${tx.tx_id}`;
+      logger.error(errMsg);
+      throw new Error(errMsg);
     }
     this.emit('txUpdate', tx.tx_id);
   }

--- a/src/migrations/1591291822107_mempool_txs.ts
+++ b/src/migrations/1591291822107_mempool_txs.ts
@@ -1,0 +1,91 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('mempool_txs', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    tx_id: {
+      type: 'bytea',
+      notNull: true,
+    },
+    type_id: {
+      notNull: true,
+      type: 'smallint',
+    },
+    status: {
+      notNull: true,
+      type: 'smallint',
+    },
+    post_conditions: {
+      type: 'bytea',
+      notNull: true,
+    },
+    fee_rate: {
+      type: 'bigint',
+      notNull: true,
+    },
+    sponsored: {
+      type: 'boolean',
+      notNull: true,
+    },
+    sender_address: {
+      type: 'string',
+      notNull: true,
+    },
+    origin_hash_mode: {
+      type: 'smallint',
+      notNull: true,
+    },
+
+    // `token-transfer` tx types
+    token_transfer_recipient_address: 'string',
+    token_transfer_amount: 'bigint',
+    token_transfer_memo: 'bytea',
+
+    // `smart-contract` tx types
+    smart_contract_contract_id: 'string',
+    smart_contract_source_code: 'string',
+
+    // `contract-call` tx types
+    contract_call_contract_id: 'string',
+    contract_call_function_name: 'string',
+    contract_call_function_args: 'bytea',
+
+    // `poison-microblock` tx types
+    poison_microblock_header_1: 'bytea',
+    poison_microblock_header_2: 'bytea',
+
+    // `coinbase` tx types
+    coinbase_payload: 'bytea',
+
+  });
+
+  pgm.createIndex('mempool_txs', 'tx_id');
+  pgm.createIndex('mempool_txs', 'type_id');
+  pgm.createIndex('mempool_txs', 'sender_address');
+  pgm.createIndex('mempool_txs', 'token_transfer_recipient_address');
+
+  pgm.addConstraint('mempool_txs', 'unique_tx_id', `UNIQUE(tx_id)`);
+
+  pgm.addConstraint('mempool_txs', 'valid_token_transfer', `CHECK (type_id != 0 OR (
+    NOT (token_transfer_recipient_address, token_transfer_amount, token_transfer_memo) IS NULL
+  ))`);
+
+  pgm.addConstraint('mempool_txs', 'valid_smart_contract', `CHECK (type_id != 1 OR (
+    NOT (smart_contract_contract_id, smart_contract_source_code) IS NULL
+  ))`);
+
+  pgm.addConstraint('mempool_txs', 'valid_contract_call', `CHECK (type_id != 2 OR (
+    NOT (contract_call_contract_id, contract_call_function_name, contract_call_function_args) IS NULL
+  ))`);
+
+  pgm.addConstraint('mempool_txs', 'valid_poison_microblock', `CHECK (type_id != 3 OR (
+    NOT (poison_microblock_header_1, poison_microblock_header_2) IS NULL
+  ))`);
+
+  pgm.addConstraint('mempool_txs', 'valid_coinbase', `CHECK (type_id != 4 OR (
+    NOT (coinbase_payload) IS NULL
+  ))`);
+}

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -1727,13 +1727,24 @@ describe('postgres datastore', () => {
 
     const reorgResult = await db.handleReorg(client, block5, 0);
     expect(reorgResult).toEqual({
-      blocks: 4,
-      txs: 2,
-      stxEvents: 0,
-      ftEvents: 0,
-      nftEvents: 0,
-      contractLogs: 0,
-      smartContracts: 0,
+      markedCanonical: {
+        blocks: 4,
+        txs: 2,
+        stxEvents: 0,
+        ftEvents: 0,
+        nftEvents: 0,
+        contractLogs: 0,
+        smartContracts: 0,
+      },
+      markedNonCanonical: {
+        blocks: 1,
+        txs: 0,
+        stxEvents: 0,
+        ftEvents: 0,
+        nftEvents: 0,
+        contractLogs: 0,
+        smartContracts: 0,
+      },
     });
 
     const blockQuery1 = await db.getBlock(block1.block_hash);

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -9,7 +9,10 @@ export default async (): Promise<void> => {
     process.env.NODE_ENV = 'test';
   }
   loadDotEnv();
-  const server = await startEventServer(new MemoryDataStore(), () => {});
+  const server = await startEventServer(new MemoryDataStore(), {
+    handleBlockMessage: () => {},
+    handleMempoolTxs: () => {},
+  });
   Object.assign(global, { server: server });
   console.log('Waiting for RPC connection to core node..');
   await new StacksCoreRpcClient().waitForConnection(60000);

--- a/stacks-blockchain/Stacks-mocknet.toml
+++ b/stacks-blockchain/Stacks-mocknet.toml
@@ -6,7 +6,7 @@ rpc_bind = "0.0.0.0:20443"
 [burnchain]
 chain = "bitcoin"
 mode = "mocknet"
-commit_anchor_block_within = 2500
+commit_anchor_block_within = 10000
 
 [[mstx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/137

Mempool transactions are stored in postgres, and returned by the `/sidecar/v1/tx/<tx_id>` endpoint. Transactions are moved out of the mempool when minted into a canonical block, including during reorg events.

### Consumer notes
When the endpoint returns a mempool tx, it will have a `status` value of `"pending"`, and the response object does _not_ include the following block-dependent properties: 
* `block_hash`
* `block_height`
* `burn_block_time`
* `canonical`
* `tx_index`


Additionally, because mempool transaction have not yet been processed, the `events` property will never be populated -- a mempool tx will not have `stx`, `ft`, `nft`, or `contract log` events available until the tx is mined. 

### Testing
The mocknet at https://crashy-stacky.zone117x.com/sidecar/v1/tx has been updated to use this PR. The block time on the mocknet has been bumped to 10 seconds to allow easier testing/dev for mempool txs. 