### PR TITLE
feat: Transaction Updates via Websockets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10391,12 +10391,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "chnl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/chnl/-/chnl-1.2.0.tgz",
-      "integrity": "sha512-g5gJb59edwCliFbX2j7G6sBfY4sX9YLy211yctONI2GRaiX0f2zIbKWmBm+sPqFNEpM7Ljzm7IJX/xrjiEbPrw==",
-      "dev": true
-    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -15188,23 +15182,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise-controller": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/promise-controller/-/promise-controller-1.0.0.tgz",
-      "integrity": "sha512-goA0zA9L91tuQbUmiMinSYqlyUtEgg4fxJcjYnLYOQnrktb4o4UqciXDNXiRUPiDBPACmsr1k8jDW4r7UDq9Qw==",
-      "dev": true
-    },
-    "promise.prototype.finally": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.2.tgz",
-      "integrity": "sha512-A2HuJWl2opDH0EafgdjwEw7HysI8ff/n4lW4QEVBCUXFk9QeGecBWv0Deph0UmLe3tTNYegz8MOjsVuE6SMoJA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.0",
-        "function-bind": "^1.1.1"
-      }
-    },
     "prompts": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -17174,17 +17151,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
-    },
-    "websocket-as-promised": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/websocket-as-promised/-/websocket-as-promised-1.0.1.tgz",
-      "integrity": "sha512-+gBevna4yxisb8cigL8NxcS8s241cvfMeyy1fNFcFgBcX/6vknMT84MwMmBNLYmsYH2giVoxOSEiAeeb7txFOw==",
-      "dev": true,
-      "requires": {
-        "chnl": "^1.0.0",
-        "promise-controller": "^1.0.0",
-        "promise.prototype.finally": "^3.1.1"
-      }
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9310,6 +9310,14 @@
       "integrity": "sha512-PUdqTZVrNYTNcIhLHkiaYzoOIaUi5LFg/XLerAdgvwQrUCx+oSbtoBze1AMyvYbcwzUSNC+Isl58SM4Sm/6COw==",
       "dev": true
     },
+    "@types/ws": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.5.tgz",
+      "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
@@ -10381,6 +10389,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "chnl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/chnl/-/chnl-1.2.0.tgz",
+      "integrity": "sha512-g5gJb59edwCliFbX2j7G6sBfY4sX9YLy211yctONI2GRaiX0f2zIbKWmBm+sPqFNEpM7Ljzm7IJX/xrjiEbPrw==",
       "dev": true
     },
     "cipher-base": {
@@ -15174,6 +15188,23 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-controller": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-controller/-/promise-controller-1.0.0.tgz",
+      "integrity": "sha512-goA0zA9L91tuQbUmiMinSYqlyUtEgg4fxJcjYnLYOQnrktb4o4UqciXDNXiRUPiDBPACmsr1k8jDW4r7UDq9Qw==",
+      "dev": true
+    },
+    "promise.prototype.finally": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.2.tgz",
+      "integrity": "sha512-A2HuJWl2opDH0EafgdjwEw7HysI8ff/n4lW4QEVBCUXFk9QeGecBWv0Deph0UmLe3tTNYegz8MOjsVuE6SMoJA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0",
+        "function-bind": "^1.1.1"
+      }
+    },
     "prompts": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -17144,6 +17175,17 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
     },
+    "websocket-as-promised": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/websocket-as-promised/-/websocket-as-promised-1.0.1.tgz",
+      "integrity": "sha512-+gBevna4yxisb8cigL8NxcS8s241cvfMeyy1fNFcFgBcX/6vknMT84MwMmBNLYmsYH2giVoxOSEiAeeb7txFOw==",
+      "dev": true,
+      "requires": {
+        "chnl": "^1.0.0",
+        "promise-controller": "^1.0.0",
+        "promise.prototype.finally": "^3.1.1"
+      }
+    },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -17378,10 +17420,9 @@
       }
     },
     "ws": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
-      "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
-      "dev": true
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "rimraf": "^3.0.2",
     "supertest": "^4.0.2",
     "ts-jest": "^25.2.1",
-    "ts-node": "^8.8.1",
-    "websocket-as-promised": "^1.0.1"
+    "ts-node": "^8.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@awaitjs/express": "^0.5.1",
     "@blockstack/stacks-blockchain-sidecar-types": "file:docs",
     "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#f5fd7c05188df67705504679d290fb684c2ee988",
+    "@types/ws": "^7.2.5",
     "big-integer": "^1.6.48",
     "bitcoinjs-lib": "^5.1.7",
     "bluebird": "^3.7.2",
@@ -62,7 +63,8 @@
     "strict-event-emitter-types": "^2.0.0",
     "typescript": "^3.9.5",
     "uuid": "^8.0.0",
-    "winston": "^3.2.1"
+    "winston": "^3.2.1",
+    "ws": "^7.3.0"
   },
   "devDependencies": {
     "@actions/core": "^1.2.4",
@@ -98,6 +100,7 @@
     "rimraf": "^3.0.2",
     "supertest": "^4.0.2",
     "ts-jest": "^25.2.1",
-    "ts-node": "^8.8.1"
+    "ts-node": "^8.8.1",
+    "websocket-as-promised": "^1.0.1"
   }
 }

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -1,4 +1,5 @@
 import { Server, createServer } from 'http';
+import { Socket } from 'net';
 import * as express from 'express';
 import * as expressWinston from 'express-winston';
 import { v4 as uuid } from 'uuid';
@@ -23,6 +24,7 @@ export interface ApiServer {
   server: Server;
   wss: WebSocket.Server;
   address: string;
+  terminate: () => Promise<void>;
 }
 
 export async function startApiServer(
@@ -124,6 +126,15 @@ export async function startApiServer(
   datastore.addListener('txUpdate', onTxUpdate);
 
   let server = createServer(app);
+
+  const serverSockets = new Set<Socket>();
+  server.on('connection', socket => {
+    serverSockets.add(socket);
+    socket.on('close', () => {
+      serverSockets.delete(socket);
+    });
+  });
+
   const wss = new WebSocket.Server({ server, path: '/sidecar/v1' });
   wss.on('connection', function (ws) {
     ws.on('message', txid => {
@@ -154,6 +165,30 @@ export async function startApiServer(
     }
   });
 
+  const terminate = async () => {
+    for (const socket of serverSockets) {
+      socket.destroy();
+    }
+    await new Promise((resolve, reject) =>
+      wss.close(error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      })
+    );
+    await new Promise((resolve, reject) =>
+      server.close(error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      })
+    );
+  };
+
   const addr = server.address();
   if (addr === null) {
     throw new Error('server missing address');
@@ -164,5 +199,6 @@ export async function startApiServer(
     server: server,
     wss: wss,
     address: addrStr,
+    terminate,
   };
 }

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -121,7 +121,7 @@ export async function startApiServer(datastore: DataStore): Promise<ApiServer> {
   datastore.addListener('txUpdate', onTxUpdate);
 
   let server = createServer(app);
-  const wss = new WebSocket.Server({ server, path: '/sidecar/v1/ws' });
+  const wss = new WebSocket.Server({ server, path: '/sidecar/v1' });
   wss.on('connection', function (ws) {
     ws.on('message', txid => {
       const id = txid.toString();

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -1,11 +1,12 @@
-import { Server } from 'http';
+import { Server, createServer } from 'http';
 import * as express from 'express';
 import * as expressWinston from 'express-winston';
 import { v4 as uuid } from 'uuid';
 import * as cors from 'cors';
 import { addAsync, ExpressWithAsync } from '@awaitjs/express';
+import * as WebSocket from 'ws';
 
-import { DataStore } from '../datastore/common';
+import { DataStore, DbTx } from '../datastore/common';
 import { createTxRouter } from './routes/tx';
 import { createDebugRouter } from './routes/debug';
 import { createContractRouter } from './routes/contract';
@@ -13,12 +14,14 @@ import { createCoreNodeRpcProxyRouter } from './routes/core-node-rpc-proxy';
 import { createBlockRouter } from './routes/block';
 import { createFaucetRouter } from './routes/faucets';
 import { createAddressRouter } from './routes/address';
-import { logger } from '../helpers';
 import { createSearchRouter } from './routes/search';
+import { logger, logError, sendWsTxUpdate } from '../helpers';
+import { getTxFromDataStore } from './controllers/db-controller';
 
 export interface ApiServer {
   expressApp: ExpressWithAsync;
   server: Server;
+  wss: WebSocket.Server;
   address: string;
 }
 
@@ -91,9 +94,58 @@ export async function startApiServer(datastore: DataStore): Promise<ApiServer> {
     })
   );
 
-  const server = await new Promise<Server>((resolve, reject) => {
+  const dbTxUpdate = async (tx: DbTx): Promise<void> => {
+    if (tx_subscribers.has(tx.tx_id)) {
+      try {
+        const txQuery = await getTxFromDataStore(tx.tx_id, datastore);
+        if (!txQuery.found) {
+          throw new Error('error in tx stream, tx not found');
+        }
+        tx_subscribers
+          .get(tx.tx_id)
+          ?.forEach(subscriber =>
+            sendWsTxUpdate(subscriber, txQuery.result.tx_id, txQuery.result.tx_status)
+          );
+      } catch (error) {
+        logError('error streaming tx updates', error);
+      }
+    }
+  };
+
+  // EventEmitters don't like being passed Promise functions so wrap the async handler
+  const onTxUpdate = (tx: DbTx): void => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    dbTxUpdate(tx);
+  };
+
+  datastore.addListener('txUpdate', onTxUpdate);
+
+  let server = createServer(app);
+  const wss = new WebSocket.Server({ server, path: '/sidecar/v1/ws' });
+  wss.on('connection', function (ws) {
+    ws.on('message', txid => {
+      const id = txid.toString();
+      const connections = tx_subscribers.get(id);
+      if (connections) {
+        connections.add(ws);
+      } else {
+        tx_subscribers.set(id, new Set([ws]));
+      }
+    });
+
+    ws.on('close', () => {
+      tx_subscribers.forEach((subscribers, txid) => {
+        subscribers.delete(ws);
+        if (subscribers.size === 0) {
+          tx_subscribers.delete(txid);
+        }
+      });
+    });
+  });
+
+  server = await new Promise<Server>((resolve, reject) => {
     try {
-      const server = app.listen(apiPort, apiHost, () => resolve(server));
+      server.listen(apiPort, apiHost, () => resolve(server));
     } catch (error) {
       reject(error);
     }
@@ -107,6 +159,7 @@ export async function startApiServer(datastore: DataStore): Promise<ApiServer> {
   return {
     expressApp: app,
     server: server,
+    wss: wss,
     address: addrStr,
   };
 }

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -262,8 +262,8 @@ function createMessageProcessorQueue(): EventMessageHandler {
 
 export async function startEventServer(
   db: DataStore,
-  messageHandler: EventMessageHandler = createMessageProcessorQueue(),
-  tx_subscribers: Map<string, Set<WebSocket>>
+  tx_subscribers: Map<string, Set<WebSocket>>,
+  messageHandler: EventMessageHandler = createMessageProcessorQueue()
 ): Promise<net.Server> {
   let eventHost = process.env['STACKS_SIDECAR_EVENT_HOST'];
   const eventPort = parseInt(process.env['STACKS_SIDECAR_EVENT_PORT'] ?? '', 10);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -295,14 +295,14 @@ export function timeout(ms: number): Promise<void> {
   });
 }
 
-export function waiter(): Promise<void> & {
-  finish: () => void;
+export function waiter<T = void>(): Promise<T> & {
+  finish: (result: T) => void;
 } {
-  let resolveFn: () => void;
-  const promise = new Promise<void>(resolve => {
+  let resolveFn: (result: T) => void;
+  const promise = new Promise<T>(resolve => {
     resolveFn = resolve;
   });
-  return Object.assign(promise, { finish: () => resolveFn() });
+  return Object.assign(promise, { finish: (result: T) => resolveFn(result) });
 }
 
 export function stopwatch(): {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,6 +4,8 @@ import * as dotenv from 'dotenv';
 import * as path from 'path';
 import * as winston from 'winston';
 import { c32addressDecode } from 'c32check';
+import * as WebSocket from 'ws';
+import { TransactionStatus } from '@blockstack/stacks-blockchain-sidecar-types';
 
 export const isDevEnv = process.env.NODE_ENV === 'development';
 export const isTestEnv = process.env.NODE_ENV === 'test';
@@ -406,3 +408,7 @@ export function cssEscape(value: string): string {
 }
 
 export const has0xPrefix = (id: string) => id.substr(0, 2).toLowerCase() === '0x';
+
+export function sendWsTxUpdate(ws: WebSocket, txId: string, status: TransactionStatus) {
+  ws.send(JSON.stringify({ txId, status }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ async function monitorCoreRpcConnection(): Promise<void> {
 
 async function init(): Promise<void> {
   let db: DataStore;
-  const tx_ws_subs: Map<string, Set<WebSocket>> = new Map();
+  const txWsSubs: Map<string, Set<WebSocket>> = new Map();
   switch (process.env['STACKS_SIDECAR_DB']) {
     case 'memory': {
       logger.info('using in-memory db');
@@ -46,11 +46,11 @@ async function init(): Promise<void> {
       throw new Error(`invalid STACKS_SIDECAR_DB option: "${process.env['STACKS_SIDECAR_DB']}"`);
     }
   }
-  await startEventServer(db, tx_ws_subs);
+  await startEventServer(db, txWsSubs);
   monitorCoreRpcConnection().catch(error => {
     logger.error(`Error monitoring RPC connection: ${error}`, error);
   });
-  const apiServer = await startApiServer(db, tx_ws_subs);
+  const apiServer = await startApiServer(db, txWsSubs);
   logger.info(`API server listening on: http://${apiServer.address}`);
 }
 

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -44,7 +44,7 @@ describe('api tests', () => {
     await cycleMigrations();
     db = await PgDataStore.connect();
     client = await db.pool.connect();
-    api = await startApiServer(db);
+    api = await startApiServer(db, new Map());
   });
 
   test('search term - hash', async () => {

--- a/src/tests/faucet-tests.ts
+++ b/src/tests/faucet-tests.ts
@@ -103,7 +103,7 @@ describe('btc faucet', () => {
     let server: Server;
 
     beforeAll(async () => {
-      const apiServer = await startApiServer(new MemoryDataStore());
+      const apiServer = await startApiServer(new MemoryDataStore(), new Map());
       server = apiServer.server;
     });
 

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,3 +1,4 @@
+import * as WebSocket from 'ws';
 import { loadDotEnv } from '../helpers';
 import { MemoryDataStore } from '../datastore/memory-store';
 import { startEventServer } from '../event-stream/event-server';
@@ -9,7 +10,7 @@ export default async (): Promise<void> => {
     process.env.NODE_ENV = 'test';
   }
   loadDotEnv();
-  const server = await startEventServer(new MemoryDataStore(), {
+  const server = await startEventServer(new MemoryDataStore(), new Map(), {
     handleBlockMessage: () => {},
     handleMempoolTxs: () => {},
   });

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -93,7 +93,7 @@ describe('websocket notifications', () => {
 
     // ws
     const addr = apiServer.address;
-    const wsAddress = `ws://${addr}/sidecar/v1/ws`;
+    const wsAddress = `ws://${addr}/sidecar/v1`;
     // const ws = new WebSocket(wsAddress);
     const wsp = new WebSocketAsPromised(wsAddress, {
       // @ts-ignore

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -1,0 +1,129 @@
+import * as WebSocket from 'ws';
+import { Server } from 'http';
+import { startApiServer } from '../api/init';
+import { MemoryDataStore } from '../datastore/memory-store';
+import { ExpressWithAsync } from '@awaitjs/express';
+import {
+  DbTx,
+  DbTxTypeId,
+  DbEventTypeId,
+  DbAssetEventTypeId,
+  DbStxEvent,
+  DataStoreUpdateData,
+  DbBlock,
+} from '../datastore/common';
+
+import WebSocketAsPromised = require('websocket-as-promised');
+
+describe('websocket notifications', () => {
+  let apiServer: {
+    expressApp: ExpressWithAsync;
+    server: Server;
+    wss: WebSocket.Server;
+    address: string;
+  };
+
+  let db: MemoryDataStore;
+  let map: Map<string, Set<WebSocket>>;
+
+  beforeAll(async () => {
+    db = new MemoryDataStore();
+    map = new Map();
+    apiServer = await startApiServer(db, map);
+  });
+
+  test('websocket connect endpoint', async done => {
+    const block: DbBlock = {
+      block_hash: '0x1234',
+      index_block_hash: '0xdeadbeef',
+      parent_index_block_hash: '0x00',
+      parent_block_hash: '0xff0011',
+      parent_microblock: '0x9876',
+      block_height: 1,
+      burn_block_time: 94869286,
+      canonical: true,
+    };
+
+    const tx: DbTx = {
+      tx_id: '0x1234',
+      tx_index: 4,
+      index_block_hash: '0x5432',
+      block_hash: '0x9876',
+      block_height: 68456,
+      burn_block_time: 2837565,
+      type_id: DbTxTypeId.TokenTransfer,
+      status: 1,
+      canonical: true,
+      post_conditions: Buffer.from([0x01, 0xf5]),
+      fee_rate: BigInt(1234),
+      sponsored: false,
+      sender_address: 'ST3GQB6WGCWKDNFNPSQRV8DY93JN06XPZ2ZE9EVMA',
+      origin_hash_mode: 1,
+      token_transfer_recipient_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+      token_transfer_amount: BigInt(100),
+      token_transfer_memo: new Buffer('memo'),
+    };
+
+    const stxEvent: DbStxEvent = {
+      canonical: tx.canonical,
+      event_type: DbEventTypeId.StxAsset,
+      asset_event_type_id: DbAssetEventTypeId.Transfer,
+      event_index: 0,
+      tx_id: tx.tx_id,
+      tx_index: tx.tx_index,
+      block_height: tx.block_height,
+      amount: tx.token_transfer_amount as bigint,
+      recipient: tx.token_transfer_recipient_address,
+      sender: tx.sender_address,
+    };
+
+    const dbUpdate: DataStoreUpdateData = {
+      block,
+      txs: [
+        {
+          tx,
+          stxEvents: [stxEvent],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          smartContracts: [],
+        },
+      ],
+    };
+
+    // ws
+    const addr = apiServer.address;
+    const wsAddress = `ws://${addr}/sidecar/v1/ws`;
+    // const ws = new WebSocket(wsAddress);
+    const wsp = new WebSocketAsPromised(wsAddress, {
+      // @ts-ignore
+      createWebSocket: url => new WebSocket(url),
+      extractMessageData: (event: any) => event,
+    });
+
+    wsp.onSend.addListener(async () => {
+      await db.update(dbUpdate);
+    });
+
+    wsp.onMessage.addListener(async (data: any) => {
+      expect(JSON.parse(data)).toEqual({ txId: tx.tx_id, status: 'success' });
+      await wsp.close();
+      done();
+    });
+
+    await wsp.open();
+    wsp.send('0x1234');
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve, reject) => {
+      apiServer.server.close(error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a websocket server that can be accessed via the endpoint `ws://<sidecar-address>/sidecar/v1`. Clients can use this endpoint to open a websocket connection to the sidecar. They can subscribe to transactions by sending a message containing just a `txid` to the server via the websocket connection. Once subscribed to a transaction, the server will stream updates to the client when the state of the transaction changes.

Example client usage with [ws](https://github.com/websockets/ws):

```javascript
const WebSocket = require('ws');

const ws = new WebSocket(`ws://localhost:3999/sidecar/v1`);

// subscribe to tx once connection is open
ws.on('open', function open() {
  ws.send('0x54da30065d7265347c43f5a6e9ec5f3a7409d802b0c5eb8e72735fec364fe075');
});

// log updates to the subscribed tx
ws.on('message', function incoming(data) {
  console.log(data);
});

```

Streaming Tx update messages take the following form:

```javascript
{
    txId: '0x54da30065d7265347c43f5a6e9ec5f3a7409d802b0c5eb8e72735fec364fe075',
    status: 'success'
}
```

Issue: #115 

Review by commit.

Considerations + Questions:
- I currently don't have a test for mempool tx updates. Not entirely sure how to implement this at the moment...
- I haven't yet implemented a way for clients to unsubscribe from transactions. Is this necessary?
- This websockets API is very simple right now (messages just contain txids) as there's only one possible action. Do we anticipate there being other use cases for websockets?