### PR TITLE
feat: store raw tx bytes in db

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-blockchain-sidecar-types",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14961,39 +14961,39 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
-      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.2.1.tgz",
+      "integrity": "sha512-DKzffhpkWRr9jx7vKxA+ur79KG+SKw+PdjMb1IRhMiKI9zqYUGczwFprqy+5Veh/DCcFs1Y6V8lRLN5I1DlleQ==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "0.1.3",
-        "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.10",
+        "pg-connection-string": "^2.2.3",
+        "pg-pool": "^3.2.1",
+        "pg-protocol": "^1.2.4",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
       }
     },
     "pg-connection-string": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.2.3.tgz",
+      "integrity": "sha512-I/KCSQGmOrZx6sMHXkOs2MjddrYcqpza3Dtsy0AjIgBr/bZiPJRK9WhABXN1Uy1UDazRbi9gZEzO2sAhL5EqiQ=="
     },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
-    "pg-packet-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
-      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
-    },
     "pg-pool": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
-      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
+      "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA=="
+    },
+    "pg-protocol": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.4.tgz",
+      "integrity": "sha512-/8L/G+vW/VhWjTGXpGh8XVkXOFx1ZDY+Yuz//Ab8CfjInzFkreI+fDG3WjCeSra7fIZwAFxzbGptNbm8xSXenw=="
     },
     "pg-types": {
       "version": "2.2.0",

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -142,7 +142,8 @@ export interface CoreNodeMessageParsed extends CoreNodeMessage {
 
 export interface CoreNodeParsedTxMessage {
   core_tx: CoreNodeTxMessage;
-  raw_tx: Transaction;
+  parsed_tx: Transaction;
+  raw_tx: Buffer;
   sender_address: string;
   block_hash: string;
   index_block_hash: string;

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -32,12 +32,16 @@ async function handleMempoolTxsMessage(rawTxs: string[], db: DataStore): Promise
   const decodedTxs = rawTxBuffers.map(buffer => {
     const txId = '0x' + digestSha512_256(buffer).toString('hex');
     const bufferReader = BufferReader.fromBuffer(buffer);
-    const rawTx = readTransaction(bufferReader);
-    const txSender = getAddressFromPublicKeyHash(rawTx.auth.originCondition.signer, rawTx.version);
+    const parsedTx = readTransaction(bufferReader);
+    const txSender = getAddressFromPublicKeyHash(
+      parsedTx.auth.originCondition.signer,
+      parsedTx.version
+    );
     return {
       txId: txId,
       sender: txSender,
-      txData: rawTx,
+      txData: parsedTx,
+      rawTx: buffer,
     };
   });
   for (const tx of decodedTxs) {
@@ -46,6 +50,7 @@ async function handleMempoolTxsMessage(rawTxs: string[], db: DataStore): Promise
       txId: tx.txId,
       txData: tx.txData,
       sender: tx.sender,
+      rawTx: tx.rawTx,
     });
     await db.updateMempoolTx({ mempoolTx: dbMempoolTx });
   }
@@ -85,13 +90,13 @@ async function handleClientMessage(msg: CoreNodeMessage, db: DataStore): Promise
       contractLogEvents: [],
       smartContracts: [],
     };
-    if (tx.raw_tx.payload.typeId === TransactionPayloadTypeID.SmartContract) {
-      const contractId = `${tx.sender_address}.${tx.raw_tx.payload.name}`;
+    if (tx.parsed_tx.payload.typeId === TransactionPayloadTypeID.SmartContract) {
+      const contractId = `${tx.sender_address}.${tx.parsed_tx.payload.name}`;
       dbData.txs[i].smartContracts.push({
         tx_id: tx.core_tx.txid,
         contract_id: contractId,
         block_height: parsedMsg.block_height,
-        source_code: tx.raw_tx.payload.codeBody,
+        source_code: tx.parsed_tx.payload.codeBody,
         abi: JSON.stringify(tx.core_tx.contract_abi),
         canonical: true,
       });

--- a/src/event-stream/reader.ts
+++ b/src/event-stream/reader.ts
@@ -46,7 +46,8 @@ export function parseMessageTransactions(msg: CoreNodeMessage): CoreNodeMessageP
       );
       const parsedTx: CoreNodeParsedTxMessage = {
         core_tx: coreTx,
-        raw_tx: rawTx,
+        raw_tx: txBuffer,
+        parsed_tx: rawTx,
         block_hash: msg.block_hash,
         index_block_hash: msg.index_block_hash,
         block_height: msg.block_height,

--- a/src/migrations/1593523025263_raw_tx_data.ts
+++ b/src/migrations/1593523025263_raw_tx_data.ts
@@ -1,0 +1,42 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  /*
+  pgm.createTable('proxied_txs', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    time_received: {
+      type: 'timestamp',
+      notNull: true,
+    },
+    raw_tx: {
+      type: 'bytea',
+      notNull: true,
+    },
+  });
+  */
+
+  pgm.addColumn('txs', {
+    raw_tx: {
+      type: 'bytea',
+      notNull: true,
+      default: '\\x', // default to empty byte array
+    },
+  });
+
+  pgm.addColumn('mempool_txs', {
+    raw_tx: {
+      type: 'bytea',
+      notNull: true,
+      default: '\\x', // default to empty byte array
+    },
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // pgm.dropTable('proxied_txs');
+  pgm.dropColumn('txs', 'raw_tx');
+  pgm.dropColumn('mempool_txs', 'raw_tx');
+}

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -62,6 +62,7 @@ describe('api tests', () => {
     const tx: DbTx = {
       tx_id: '0x4567000000000000000000000000000000000000000000000000000000000000',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: block.index_block_hash,
       block_hash: block.block_hash,
       block_height: 68456,
@@ -81,6 +82,7 @@ describe('api tests', () => {
 
     const mempoolTx: DbMempoolTx = {
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
+      raw_tx: Buffer.from('test-raw-tx'),
       type_id: DbTxTypeId.Coinbase,
       coinbase_payload: Buffer.from('coinbase hi'),
       status: 1,
@@ -244,6 +246,7 @@ describe('api tests', () => {
     const stxTx1: DbTx = {
       tx_id: '0x1111000000000000000000000000000000000000000000000000000000000000',
       tx_index: 0,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -279,6 +282,7 @@ describe('api tests', () => {
     const stxTx2: DbTx = {
       tx_id: '0x2222000000000000000000000000000000000000000000000000000000000000',
       tx_index: 0,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -480,6 +484,7 @@ describe('api tests', () => {
     const smartContract: DbTx = {
       type_id: DbTxTypeId.SmartContract,
       tx_id: '0x1111880000000000000000000000000000000000000000000000000000000000',
+      raw_tx: Buffer.alloc(0),
       canonical: true,
       smart_contract_contract_id: contractAddr1,
       smart_contract_source_code: '(some-src)',
@@ -521,6 +526,7 @@ describe('api tests', () => {
     const smartContractMempoolTx: DbMempoolTx = {
       type_id: DbTxTypeId.SmartContract,
       tx_id: '0x1111882200000000000000000000000000000000000000000000000000000000',
+      raw_tx: Buffer.from('test-raw-tx'),
       smart_contract_contract_id: contractAddr2,
       smart_contract_source_code: '(some-src)',
       status: 1,
@@ -599,6 +605,7 @@ describe('api tests', () => {
       const tx: DbTx = {
         tx_id: '0x1234' + (++indexIdIndex).toString().padStart(4, '0'),
         tx_index: indexIdIndex,
+        raw_tx: Buffer.alloc(0),
         index_block_hash: '0x5432',
         block_hash: '0x9876',
         block_height: 68456,
@@ -634,6 +641,7 @@ describe('api tests', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -1025,6 +1033,7 @@ describe('api tests', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: block.index_block_hash,
       block_hash: block.block_hash,
       block_height: 68456,
@@ -1107,7 +1116,8 @@ describe('api tests', () => {
         tx_index: 2,
         contract_abi: null,
       },
-      raw_tx: tx,
+      raw_tx: Buffer.alloc(0),
+      parsed_tx: tx,
       sender_address: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
       index_block_hash: '0xaa',
       block_hash: '0xff',
@@ -1237,7 +1247,8 @@ describe('api tests', () => {
         tx_index: 2,
         contract_abi: null,
       },
-      raw_tx: tx,
+      raw_tx: Buffer.alloc(0),
+      parsed_tx: tx,
       sender_address: 'SP2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7GB36ZAR0',
       index_block_hash: '0xaa',
       block_hash: '0xff',
@@ -1305,7 +1316,8 @@ describe('api tests', () => {
         tx_index: 2,
         contract_abi: null,
       },
-      raw_tx: tx,
+      raw_tx: Buffer.alloc(0),
+      parsed_tx: tx,
       sender_address: 'SP2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7GB36ZAR0',
       index_block_hash: '0xaa',
       block_hash: '0xff',

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -65,6 +65,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -143,6 +144,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -229,6 +231,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -331,6 +334,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: block.index_block_hash,
       block_hash: block.block_hash,
       block_height: 68456,
@@ -363,6 +367,7 @@ describe('postgres datastore', () => {
       const tx: DbTx = {
         tx_id: '0x1234' + (++indexIdIndex).toString().padStart(4, '0'),
         tx_index: indexIdIndex,
+        raw_tx: Buffer.alloc(0),
         index_block_hash: '0x5432',
         block_hash: '0x9876',
         block_height: 68456,
@@ -512,6 +517,7 @@ describe('postgres datastore', () => {
     const tx1: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -562,6 +568,7 @@ describe('postgres datastore', () => {
     const tx2: DbTx = {
       tx_id: '0x1234',
       tx_index: 3,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -623,6 +630,7 @@ describe('postgres datastore', () => {
     const tx3: DbTx = {
       tx_id: '0x1234',
       tx_index: 2,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
@@ -1306,6 +1314,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x3434',
       block_hash: '0x5678',
       block_height: 68456,
@@ -1331,6 +1340,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x3434',
       block_hash: '0x5678',
       block_height: 68456,
@@ -1361,6 +1371,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x3434',
       block_hash: '0x5678',
       block_height: 68456,
@@ -1390,6 +1401,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x3434',
       block_hash: '0x5678',
       block_height: 68456,
@@ -1420,6 +1432,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x3434',
       block_hash: '0x5678',
       block_height: 68456,
@@ -1449,6 +1462,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x421234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x3434',
       block_hash: '0x5678',
       block_height: 68456,
@@ -1477,6 +1491,7 @@ describe('postgres datastore', () => {
     const tx: DbTx = {
       tx_id: '0x1234',
       tx_index: 4,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x5555',
       block_hash: '0x5678',
       block_height: 68456,
@@ -1515,6 +1530,7 @@ describe('postgres datastore', () => {
     const tx1: DbTx = {
       tx_id: '0x421234',
       tx_index: 0,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: '0x1234',
       block_hash: '0x5678',
       block_height: block1.block_height,
@@ -1718,6 +1734,7 @@ describe('postgres datastore', () => {
 
     const tx1Mempool: DbMempoolTx = {
       tx_id: '0x01',
+      raw_tx: Buffer.from('test-raw-tx'),
       type_id: DbTxTypeId.TokenTransfer,
       token_transfer_amount: BigInt(1),
       token_transfer_memo: Buffer.from('hi'),
@@ -1732,6 +1749,7 @@ describe('postgres datastore', () => {
     const tx1: DbTx = {
       ...tx1Mempool,
       tx_index: 0,
+      raw_tx: Buffer.from('test-raw-tx'),
       index_block_hash: block3B.index_block_hash,
       block_hash: block3B.block_hash,
       block_height: block3B.block_height,
@@ -1755,6 +1773,9 @@ describe('postgres datastore', () => {
     const txQuery1 = await db.getMempoolTx(tx1Mempool.tx_id);
     expect(txQuery1.found).toBe(true);
     expect(txQuery1?.result?.status).toBe(DbTxStatus.Pending);
+    expect(txQuery1?.result?.raw_tx.toString('hex')).toBe(
+      Buffer.from('test-raw-tx').toString('hex')
+    );
 
     for (const block of [block1, block2, block3]) {
       await db.update({
@@ -1796,6 +1817,9 @@ describe('postgres datastore', () => {
     expect(txQuery4.found).toBe(true);
     expect(txQuery4?.result?.status).toBe(DbTxStatus.Success);
     expect(txQuery4?.result?.canonical).toBe(true);
+    expect(txQuery4?.result?.raw_tx.toString('hex')).toBe(
+      Buffer.from('test-raw-tx').toString('hex')
+    );
 
     // reorg the chain to make the tx no longer canonical
     for (const block of [block4, block5]) {
@@ -1895,6 +1919,7 @@ describe('postgres datastore', () => {
     const tx1: DbTx = {
       tx_id: '0x01',
       tx_index: 0,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: block1.index_block_hash,
       block_hash: block1.block_hash,
       block_height: block1.block_height,
@@ -1914,6 +1939,7 @@ describe('postgres datastore', () => {
     const tx2: DbTx = {
       tx_id: '0x02',
       tx_index: 0,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: block2.index_block_hash,
       block_hash: block2.block_hash,
       block_height: block2.block_height,
@@ -2018,6 +2044,7 @@ describe('postgres datastore', () => {
     const tx1: DbTx = {
       tx_id: '0x01',
       tx_index: 0,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: block1.index_block_hash,
       block_hash: block1.block_hash,
       block_height: block1.block_height,
@@ -2037,6 +2064,7 @@ describe('postgres datastore', () => {
     const tx2: DbTx = {
       tx_id: '0x02',
       tx_index: 0,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: block2.index_block_hash,
       block_hash: block2.block_hash,
       block_height: block2.block_height,
@@ -2094,6 +2122,7 @@ describe('postgres datastore', () => {
     const tx3: DbTx = {
       tx_id: '0x03',
       tx_index: 0,
+      raw_tx: Buffer.alloc(0),
       index_block_hash: block2b.index_block_hash,
       block_hash: block2b.block_hash,
       block_height: block2b.block_height,


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/149

Raw transaction bytes are now stored in the tx and mempool tx tables. 