### PR TITLE
feat: contract event enumeration endpoint

### DIFF
--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -18,7 +18,7 @@ const parseTxQueryLimit = parseLimitQuery({
 
 const parseAssetsQueryLimit = parseLimitQuery({
   maxItems: MAX_ASSETS_PER_REQUEST,
-  errorMsg: '`limit` must be equal to or less than ' + MAX_TX_PER_REQUEST,
+  errorMsg: '`limit` must be equal to or less than ' + MAX_ASSETS_PER_REQUEST,
 });
 
 // TODO: define this in json schema

--- a/src/api/routes/contract.ts
+++ b/src/api/routes/contract.ts
@@ -1,6 +1,14 @@
 import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../datastore/common';
+import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
+import { parseDbEvent } from '../controllers/db-controller';
+
+const MAX_EVENTS_PER_REQUEST = 50;
+const parseContractEventsQueryLimit = parseLimitQuery({
+  maxItems: MAX_EVENTS_PER_REQUEST,
+  errorMsg: '`limit` must be equal to or less than ' + MAX_EVENTS_PER_REQUEST,
+});
 
 export function createContractRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
@@ -12,6 +20,19 @@ export function createContractRouter(db: DataStore): RouterWithAsync {
       return;
     }
     res.json(contractQuery.result);
+  });
+
+  router.getAsync('/:contract_id/events', async (req, res) => {
+    const { contract_id } = req.params;
+    const limit = parseContractEventsQueryLimit(req.query.limit ?? 20);
+    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+    const eventsQuery = await db.getSmartContractEvents({ contractId: contract_id, limit, offset });
+    if (!eventsQuery.found) {
+      res.status(404).json({ error: `cannot find events for contract by ID: ${contract_id}` });
+      return;
+    }
+    const parsedEvents = eventsQuery.result.map(event => parseDbEvent(event));
+    res.json({ limit, offset, results: parsedEvents });
   });
 
   return router;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
 import { EventEmitter } from 'events';
 import StrictEventEmitter from 'strict-event-emitter-types';
-import { hexToBuffer, parseEnum } from '../helpers';
+import { hexToBuffer, parseEnum, FoundOrNot } from '../helpers';
 import { CoreNodeParsedTxMessage, CoreNodeTxStatus } from '../event-stream/core-node-message';
 import {
   TransactionAuthTypeID,
@@ -238,15 +238,15 @@ export interface DbSearchResult {
 }
 
 export interface DataStore extends DataStoreEventEmitter {
-  getBlock(blockHash: string): Promise<{ found: true; result: DbBlock } | { found: false }>;
+  getBlock(blockHash: string): Promise<FoundOrNot<DbBlock>>;
   getBlocks(args: {
     limit: number;
     offset: number;
   }): Promise<{ results: DbBlock[]; total: number }>;
   getBlockTxs(indexBlockHash: string): Promise<{ results: string[] }>;
 
-  getMempoolTx(txId: string): Promise<{ found: true; result: DbMempoolTx } | { found: false }>;
-  getTx(txId: string): Promise<{ found: true; result: DbTx } | { found: false }>;
+  getMempoolTx(txId: string): Promise<FoundOrNot<DbMempoolTx>>;
+  getTx(txId: string): Promise<FoundOrNot<DbTx>>;
   getTxList(args: {
     limit: number;
     offset: number;
@@ -255,9 +255,13 @@ export interface DataStore extends DataStoreEventEmitter {
 
   getTxEvents(txId: string, indexBlockHash: string): Promise<{ results: DbEvent[] }>;
 
-  getSmartContract(
-    contractId: string
-  ): Promise<{ found: true; result: DbSmartContract } | { found: false }>;
+  getSmartContract(contractId: string): Promise<FoundOrNot<DbSmartContract>>;
+
+  getSmartContractEvents(args: {
+    contractId: string;
+    limit: number;
+    offset: number;
+  }): Promise<FoundOrNot<DbSmartContractEvent[]>>;
 
   update(data: DataStoreUpdateData): Promise<void>;
 
@@ -289,13 +293,9 @@ export interface DataStore extends DataStoreEventEmitter {
     offset: number;
   }): Promise<{ results: DbEvent[]; total: number }>;
 
-  searchHash(args: {
-    hash: string;
-  }): Promise<{ found: false } | { found: true; result: DbSearchResult }>;
+  searchHash(args: { hash: string }): Promise<FoundOrNot<DbSearchResult>>;
 
-  searchPrincipal(args: {
-    principal: string;
-  }): Promise<{ found: false } | { found: true; result: DbSearchResult }>;
+  searchPrincipal(args: { principal: string }): Promise<FoundOrNot<DbSearchResult>>;
 
   insertFaucetRequest(faucetRequest: DbFaucetRequest): Promise<void>;
 }

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -16,7 +16,7 @@ import {
   DbMempoolTx,
   DbSearchResult,
 } from './common';
-import { logger } from '../helpers';
+import { logger, FoundOrNot } from '../helpers';
 import { TransactionType } from '@blockstack/stacks-blockchain-sidecar-types';
 import { getTxTypeId } from '../api/controllers/db-controller';
 
@@ -260,6 +260,14 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
       return Promise.resolve({ found: false } as const);
     }
     return Promise.resolve({ found: true, result: entries[0].entry });
+  }
+
+  getSmartContractEvents(args: {
+    contractId: string;
+    limit: number;
+    offset: number;
+  }): Promise<FoundOrNot<DbSmartContractEvent[]>> {
+    throw new Error('not yet implemented');
   }
 
   getStxBalance(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -287,6 +287,8 @@ export function assertNotNullish<T>(val: T, onNullish?: () => string): Exclude<T
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ElementType<T extends any[]> = T extends (infer U)[] ? U : never;
 
+export type FoundOrNot<T> = { found: true; result: T } | { found: false };
+
 export function timeout(ms: number): Promise<void> {
   return new Promise(resolve => {
     setTimeout(() => {


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/150
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/141
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/148

This PR creates a new endpoint that returns the contract-log-events emitted on a given contract:
`GET /sidecar/v1/contract/<contract_id>/events` 

* `limit` and `offset` query params supported.
* Ordered by most recent -- DESC block height, tx index, event index.

Example: `/sidecar/v1/contract/hello-world/events?limit=20&offset=0`

```ts
{
  limit: 20,
  offset: 0,
  results: [
    {
      event_index: 4,
      event_type: 'smart_contract_log',
      contract_log: {
        contract_id: 'hello-world',
        topic: 'print', // note that the Clarity `print` statement is the only possibly event topic for now
        value: { hex: '0x0200000008736f6d652076616c', repr: '"some val"' },
      },
    },
  ],
}
```

----

* This is currently returning event objects matching the existing json schema for `TransactionEventSmartContractLog` (sub-type of `TransactionEvent`). Should the entries be extended to include more info like the txid?