### PR TITLE
Fix address endpoint missing contract-calls and contract-deploys txs

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1653,7 +1653,12 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       WITH transactions AS (
         SELECT *, (COUNT(*) OVER())::integer as count
         FROM txs
-        WHERE canonical = true AND (sender_address = $1 OR token_transfer_recipient_address = $1)
+        WHERE canonical = true AND (
+          sender_address = $1 OR 
+          token_transfer_recipient_address = $1 OR 
+          contract_call_contract_id = $1 OR 
+          smart_contract_contract_id = $1
+        )
       )
       SELECT ${TX_COLUMNS}, count
       FROM transactions

--- a/src/migrations/1584619633448_txs.ts
+++ b/src/migrations/1584619633448_txs.ts
@@ -93,6 +93,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('txs', 'canonical');
   pgm.createIndex('txs', 'sender_address');
   pgm.createIndex('txs', 'token_transfer_recipient_address');
+  pgm.createIndex('txs', 'contract_call_contract_id');
+  pgm.createIndex('txs', 'smart_contract_contract_id');
 
   pgm.addConstraint('txs', 'unique_tx_id_index_block_hash', `UNIQUE(tx_id, index_block_hash)`);
 


### PR DESCRIPTION
Adds missing `contract-call` and `contract-deploy` txs to the `/address/:contract/transactions` endpoint response. 
Thx @hstove for finding this bug.