### PR TITLE
Include ISO 8601 formatted timestamps alongside unix epochs

### DIFF
--- a/docs/entities/blocks/block.schema.json
+++ b/docs/entities/blocks/block.schema.json
@@ -3,7 +3,7 @@
   "title": "Block",
   "description": "A block",
   "type": "object",
-  "required": ["canonical", "height", "hash", "parent_block_hash", "txs", "burn_block_time"],
+  "required": ["canonical", "height", "hash", "parent_block_hash", "txs", "burn_block_time", "burn_block_time_iso"],
   "properties": {
     "canonical": {
       "type": "boolean"
@@ -20,6 +20,10 @@
     "burn_block_time": {
       "type": "number",
       "description": "A unix timestamp (in seconds) indicating when this block was mined."
+    },
+    "burn_block_time_iso": {
+      "type": "string",
+      "description": "An ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ) indicating when this block was mined."
     },
     "txs": {
       "type": "array",

--- a/docs/entities/mempool-transactions/abstract-transaction.schema.json
+++ b/docs/entities/mempool-transactions/abstract-transaction.schema.json
@@ -9,7 +9,8 @@
     "sender_address",
     "sponsored",
     "post_condition_mode",
-    "receipt_time"
+    "receipt_time",
+    "receipt_time_iso"
   ],
   "properties": {
     "tx_id": {
@@ -48,6 +49,10 @@
     "receipt_time": {
       "type": "number",
       "description": "A unix timestamp (in seconds) indicating when the transaction broadcast was received by the node."
+    },
+    "receipt_time_iso": {
+      "type": "string",
+      "description": "An ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ) timestamp indicating when the transaction broadcast was received by the node."
     }
   }
 }

--- a/docs/entities/transactions/abstract-transaction.schema.json
+++ b/docs/entities/transactions/abstract-transaction.schema.json
@@ -8,6 +8,7 @@
     "block_hash",
     "block_height",
     "burn_block_time",
+    "burn_block_time_iso",
     "canonical",
     "tx_status",
     "fee_rate",
@@ -25,6 +26,10 @@
     "burn_block_time": {
       "type": "integer",
       "description": "A unix timestamp (in seconds) indicating when this block was mined."
+    },
+    "burn_block_time_iso": {
+      "type": "string",
+      "description": "An ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ) timestamp indicating when this block was mined."
     },
     "canonical": {
       "type": "boolean"

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -40,6 +40,10 @@ export interface Block {
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
   burn_block_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) indicating when this block was mined.
+   */
+  burn_block_time_iso: string;
   txs: string[];
 }
 
@@ -67,6 +71,10 @@ export interface MempoolTokenTransferTransaction {
    * A unix timestamp (in seconds) indicating when the transaction broadcast was received by the node.
    */
   receipt_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when the transaction broadcast was received by the node.
+   */
+  receipt_time_iso: string;
   tx_type: "token_transfer";
   token_transfer: {
     recipient_address: string;
@@ -105,6 +113,10 @@ export interface MempoolSmartContractTransaction {
    * A unix timestamp (in seconds) indicating when the transaction broadcast was received by the node.
    */
   receipt_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when the transaction broadcast was received by the node.
+   */
+  receipt_time_iso: string;
   tx_type: "smart_contract";
   smart_contract: {
     contract_id: string;
@@ -140,6 +152,10 @@ export interface MempoolContractCallTransaction {
    * A unix timestamp (in seconds) indicating when the transaction broadcast was received by the node.
    */
   receipt_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when the transaction broadcast was received by the node.
+   */
+  receipt_time_iso: string;
   tx_type: "contract_call";
   contract_call: {
     contract_id: string;
@@ -175,6 +191,10 @@ export interface MempoolPoisonMicroblockTransaction {
    * A unix timestamp (in seconds) indicating when the transaction broadcast was received by the node.
    */
   receipt_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when the transaction broadcast was received by the node.
+   */
+  receipt_time_iso: string;
   tx_type: "poison_microblock";
   poison_microblock: {
     /**
@@ -212,6 +232,10 @@ export interface MempoolCoinbaseTransaction {
    * A unix timestamp (in seconds) indicating when the transaction broadcast was received by the node.
    */
   receipt_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when the transaction broadcast was received by the node.
+   */
+  receipt_time_iso: string;
   tx_type: "coinbase";
   coinbase_payload: {
     /**
@@ -399,6 +423,10 @@ export interface TokenTransferTransaction {
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
   burn_block_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when this block was mined.
+   */
+  burn_block_time_iso: string;
   canonical: boolean;
   tx_id: string;
   tx_index: number;
@@ -442,6 +470,10 @@ export interface SmartContractTransaction {
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
   burn_block_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when this block was mined.
+   */
+  burn_block_time_iso: string;
   canonical: boolean;
   tx_id: string;
   tx_index: number;
@@ -482,6 +514,10 @@ export interface ContractCallTransaction {
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
   burn_block_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when this block was mined.
+   */
+  burn_block_time_iso: string;
   canonical: boolean;
   tx_id: string;
   tx_index: number;
@@ -529,6 +565,10 @@ export interface PoisonMicroblockTransaction {
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
   burn_block_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when this block was mined.
+   */
+  burn_block_time_iso: string;
   canonical: boolean;
   tx_id: string;
   tx_index: number;
@@ -570,6 +610,10 @@ export interface CoinbaseTransaction {
    * A unix timestamp (in seconds) indicating when this block was mined.
    */
   burn_block_time: number;
+  /**
+   * An ISO 8601 (YYYY-MM-DDTHH:mm:ssZ) timestamp indicating when this block was mined.
+   */
+  burn_block_time_iso: string;
   canonical: boolean;
   tx_id: string;
   tx_index: number;

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -37,6 +37,7 @@ import {
   bufferToHexPrefixString,
   ElementType,
   hexToBuffer,
+  unixEpochToIso,
 } from '../../helpers';
 import { readClarityValueArray, readTransactionPostConditions } from '../../p2p/tx';
 import { BufferReader } from '../../binary-reader';
@@ -227,6 +228,7 @@ export async function getBlockFromDataStore(
     hash: dbBlock.block_hash,
     parent_block_hash: dbBlock.parent_block_hash,
     burn_block_time: dbBlock.burn_block_time,
+    burn_block_time_iso: unixEpochToIso(dbBlock.burn_block_time),
     txs: txIds.results,
   };
   return { found: true, result: apiBlock };
@@ -238,6 +240,7 @@ export function parseDbMempoolTx(dbTx: DbMempoolTx): MempoolTransaction {
     tx_status: getTxStatusString(dbTx.status),
     tx_type: getTxTypeString(dbTx.type_id),
     receipt_time: dbTx.receipt_time,
+    receipt_time_iso: unixEpochToIso(dbTx.receipt_time),
 
     fee_rate: dbTx.fee_rate.toString(10),
     sender_address: dbTx.sender_address,
@@ -359,6 +362,7 @@ export async function getTxFromDataStore(
     apiTx.block_hash = fullTx.block_hash;
     apiTx.block_height = fullTx.block_height;
     apiTx.burn_block_time = fullTx.burn_block_time;
+    apiTx.burn_block_time_iso = unixEpochToIso(fullTx.burn_block_time);
     apiTx.canonical = fullTx.canonical;
     apiTx.tx_index = fullTx.tx_index;
 
@@ -373,6 +377,7 @@ export async function getTxFromDataStore(
   if ((dbTx as DbMempoolTx).receipt_time) {
     const mempoolTx = dbTx as DbMempoolTx;
     apiTx.receipt_time = mempoolTx.receipt_time;
+    apiTx.receipt_time_iso = unixEpochToIso(mempoolTx.receipt_time);
   }
 
   switch (apiTx.tx_type) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -214,6 +214,17 @@ export function parsePort(portVal: number | string | undefined): number | undefi
   }
 }
 
+/** Converts a unix timestamp (in seconds) to an ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ) string */
+export function unixEpochToIso(timestamp: number): string {
+  try {
+    const date = new Date(timestamp * 1000);
+    const iso = date.toISOString();
+    return iso;
+  } catch (error) {
+    throw error;
+  }
+}
+
 export function getCurrentGitTag(): string {
   const tagEnvVar = (process.env.GIT_TAG || '').trim();
   if (tagEnvVar) {

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -31,6 +31,7 @@ import {
   DbMempoolTx,
   DbSmartContract,
   DbSmartContractEvent,
+  DbTxStatus,
 } from '../datastore/common';
 import { startApiServer, ApiServer } from '../api/init';
 import { PgDataStore, cycleMigrations, runMigrations } from '../datastore/postgres-store';
@@ -54,9 +55,9 @@ describe('api tests', () => {
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
       raw_tx: Buffer.from('test-raw-tx'),
       type_id: DbTxTypeId.Coinbase,
-      receipt_time: (new Date('2020-07-09T15:14:55.151Z').getTime() / 1000) | 0,
+      status: DbTxStatus.Pending,
+      receipt_time: 1594307695,
       coinbase_payload: Buffer.from('coinbase hi'),
-      status: 1,
       post_conditions: Buffer.from([0x01, 0xf5]),
       fee_rate: BigInt(1234),
       sponsored: false,
@@ -70,15 +71,17 @@ describe('api tests', () => {
     expect(searchResult1.type).toBe('application/json');
     const expectedResp1 = {
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
-      tx_status: 'success',
+      tx_status: 'pending',
       tx_type: 'coinbase',
       fee_rate: '1234',
       sender_address: 'sender-addr',
       sponsored: false,
       post_condition_mode: 'allow',
       receipt_time: 1594307695,
+      receipt_time_iso: '2020-07-09T15:14:55.000Z',
       coinbase_payload: { data: '0x636f696e62617365206869' },
     };
+
     expect(JSON.parse(searchResult1.text)).toEqual(expectedResp1);
   });
 
@@ -114,6 +117,7 @@ describe('api tests', () => {
           tx_status: 'success',
           tx_type: 'coinbase',
           receipt_time: 1594307647,
+          receipt_time_iso: '2020-07-09T15:14:07.000Z',
           fee_rate: '1234',
           sender_address: 'sender-addr',
           sponsored: false,
@@ -125,6 +129,7 @@ describe('api tests', () => {
           tx_status: 'success',
           tx_type: 'coinbase',
           receipt_time: 1594307646,
+          receipt_time_iso: '2020-07-09T15:14:06.000Z',
           fee_rate: '1234',
           sender_address: 'sender-addr',
           sponsored: false,
@@ -136,6 +141,7 @@ describe('api tests', () => {
           tx_status: 'success',
           tx_type: 'coinbase',
           receipt_time: 1594307645,
+          receipt_time_iso: '2020-07-09T15:14:05.000Z',
           fee_rate: '1234',
           sender_address: 'sender-addr',
           sponsored: false,
@@ -711,7 +717,7 @@ describe('api tests', () => {
         index_block_hash: '0x5432',
         block_hash: '0x9876',
         block_height: 68456,
-        burn_block_time: 2837565,
+        burn_block_time: 1594647994,
         type_id: DbTxTypeId.TokenTransfer,
         token_transfer_amount: BigInt(amount),
         token_transfer_memo: Buffer.from('hi'),
@@ -747,7 +753,7 @@ describe('api tests', () => {
       index_block_hash: '0x5432',
       block_hash: '0x9876',
       block_height: 68456,
-      burn_block_time: 2837565,
+      burn_block_time: 1594647994,
       type_id: DbTxTypeId.Coinbase,
       coinbase_payload: Buffer.from('coinbase hi'),
       status: 1,
@@ -1044,7 +1050,8 @@ describe('api tests', () => {
           post_condition_mode: 'allow',
           block_hash: '0x9876',
           block_height: 68456,
-          burn_block_time: 2837565,
+          burn_block_time: 1594647994,
+          burn_block_time_iso: '2020-07-13T13:46:34.000Z',
           canonical: true,
           tx_index: 5,
           token_transfer: {
@@ -1068,7 +1075,8 @@ describe('api tests', () => {
           post_condition_mode: 'allow',
           block_hash: '0x9876',
           block_height: 68456,
-          burn_block_time: 2837565,
+          burn_block_time: 1594647994,
+          burn_block_time_iso: '2020-07-13T13:46:34.000Z',
           canonical: true,
           tx_index: 3,
           token_transfer: {
@@ -1092,7 +1100,8 @@ describe('api tests', () => {
           post_condition_mode: 'allow',
           block_hash: '0x9876',
           block_height: 68456,
-          burn_block_time: 2837565,
+          burn_block_time: 1594647994,
+          burn_block_time_iso: '2020-07-13T13:46:34.000Z',
           canonical: true,
           tx_index: 2,
           token_transfer: {
@@ -1115,7 +1124,7 @@ describe('api tests', () => {
       parent_block_hash: '0xff0011',
       parent_microblock: '0x9876',
       block_height: 1,
-      burn_block_time: 94869286,
+      burn_block_time: 1594647996,
       canonical: true,
     };
     const tx1: DbTx = {
@@ -1125,7 +1134,7 @@ describe('api tests', () => {
       index_block_hash: '0x1234',
       block_hash: '0x5678',
       block_height: block1.block_height,
-      burn_block_time: 2837565,
+      burn_block_time: 1594647995,
       type_id: DbTxTypeId.Coinbase,
       status: 1,
       raw_result: '0x0100000000000000000000000000000001', // u1
@@ -1224,7 +1233,7 @@ describe('api tests', () => {
       parent_block_hash: '0xff0011',
       parent_microblock: '0x9876',
       block_height: 1235,
-      burn_block_time: 94869286,
+      burn_block_time: 1594647996,
       canonical: true,
     };
     await db.updateBlock(client, block);
@@ -1235,7 +1244,7 @@ describe('api tests', () => {
       index_block_hash: block.index_block_hash,
       block_hash: block.block_hash,
       block_height: 68456,
-      burn_block_time: 2837565,
+      burn_block_time: 1594647995,
       type_id: DbTxTypeId.Coinbase,
       coinbase_payload: Buffer.from('coinbase hi'),
       status: 1,
@@ -1255,7 +1264,8 @@ describe('api tests', () => {
     }
 
     const expectedResp = {
-      burn_block_time: 94869286,
+      burn_block_time: 1594647996,
+      burn_block_time_iso: '2020-07-13T13:46:36.000Z',
       canonical: true,
       hash: '0x1234',
       height: 1235,
@@ -1320,7 +1330,7 @@ describe('api tests', () => {
       index_block_hash: '0xaa',
       block_hash: '0xff',
       block_height: 123,
-      burn_block_time: 345,
+      burn_block_time: 1594647995,
     });
     await db.updateTx(client, dbTx);
     const contractAbi: ClarityAbi = {
@@ -1354,7 +1364,8 @@ describe('api tests', () => {
     const expectedResp = {
       block_hash: '0xff',
       block_height: 123,
-      burn_block_time: 345,
+      burn_block_time: 1594647995,
+      burn_block_time_iso: '2020-07-13T13:46:35.000Z',
       canonical: true,
       tx_id: '0xc3e2fabaf7017fa2f6967db4f21be4540fdeae2d593af809c18a6adf369bfb03',
       tx_index: 2,
@@ -1451,7 +1462,7 @@ describe('api tests', () => {
       index_block_hash: '0xaa',
       block_hash: '0xff',
       block_height: 123,
-      burn_block_time: 345,
+      burn_block_time: 1594647995,
     });
     await db.updateTx(client, dbTx);
 
@@ -1464,7 +1475,8 @@ describe('api tests', () => {
     const expectedResp = {
       block_hash: '0xff',
       block_height: 123,
-      burn_block_time: 345,
+      burn_block_time: 1594647995,
+      burn_block_time_iso: '2020-07-13T13:46:35.000Z',
       canonical: true,
       tx_id: '0x79abc7783de19569106087302b02379dd02cbb52d20c6c3a7c3d79cbedd559fa',
       tx_index: 2,
@@ -1520,7 +1532,7 @@ describe('api tests', () => {
       index_block_hash: '0xaa',
       block_hash: '0xff',
       block_height: 123,
-      burn_block_time: 345,
+      burn_block_time: 1594647995,
     });
     await db.updateTx(client, dbTx);
 
@@ -1533,7 +1545,8 @@ describe('api tests', () => {
     const expectedResp = {
       block_hash: '0xff',
       block_height: 123,
-      burn_block_time: 345,
+      burn_block_time: 1594647995,
+      burn_block_time_iso: '2020-07-13T13:46:35.000Z',
       canonical: true,
       tx_id: '0x79abc7783de19569106087302b02379dd02cbb52d20c6c3a7c3d79cbedd559fa',
       tx_index: 2,


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-sidecar/issues/157

All API response objects that include a unix timestamp now also include an [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) encoded value. This provides a more readable date, and in a standardized date format, especially for JS projects, e.g. `new Date(resp.timestamp_iso)` just works.

* `block` response objects now include both a `receipt_time` and `receipt_time_iso` value, e.g.:
  ```js
  {
    burn_block_time: 1594307695,
    burn_block_time_iso: '2020-07-09T15:14:55.000Z' 
  }
  ```
* `transaction` (mined) response objects now include both a `receipt_time` and `receipt_time_iso` value, e.g.:
  ```js
  {
    burn_block_time: 1594307695,
    burn_block_time_iso: '2020-07-09T15:14:55.000Z' 
  }
  ```
* `transaction` (mempool) response objects now include both a `receipt_time` and `receipt_time_iso` value, e.g.:
  ```js
  {
    receipt_time: 1594307695,
    receipt_time_iso: '2020-07-09T15:14:55.000Z' 
  }
  ```